### PR TITLE
修复 .NET 4.5 等待连接卡线程

### DIFF
--- a/demo/dotnetCampus.Ipc.WpfDemo/View/CharPage.xaml
+++ b/demo/dotnetCampus.Ipc.WpfDemo/View/CharPage.xaml
@@ -27,6 +27,6 @@
         </ListView>
         <TextBox x:Name="MessageTextBox" Grid.Row="2" Margin="10,10,10,10"
                  Height="100" AcceptsReturn="True" TextWrapping="Wrap" />
-        <Button Grid.Row="3" Margin="10,0,10,10" HorizontalAlignment="Right" Content="Send" Click="SendButton_OnClick" />
+        <RepeatButton Grid.Row="3" Margin="10,0,10,10" HorizontalAlignment="Right" Content="Send" Click="SendButton_OnClick" />
     </Grid>
 </UserControl>

--- a/demo/dotnetCampus.Ipc.WpfDemo/dotnetCampus.Ipc.WpfDemo.csproj
+++ b/demo/dotnetCampus.Ipc.WpfDemo/dotnetCampus.Ipc.WpfDemo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net45</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/dotnetCampus.Ipc.PipeCore/Core_/IpcClientService.cs
+++ b/src/dotnetCampus.Ipc.PipeCore/Core_/IpcClientService.cs
@@ -73,15 +73,13 @@ namespace dotnetCampus.Ipc.PipeCore
         /// <returns></returns>
         public async Task Start(bool shouldRegisterToPeer = true)
         {
-            var namedPipeClientStream = new NamedPipeClientStream(".", PeerName, PipeDirection.InOut,
+            var namedPipeClientStream = new NamedPipeClientStream(".", PeerName, PipeDirection.Out,
                 PipeOptions.None, TokenImpersonationLevel.Impersonation);
 #if NETCOREAPP
             await namedPipeClientStream.ConnectAsync();
 #else
-            // 使用 Yield 释放方法，解决在 UI 上调用 await Start 方法在 Connect 等待
-            await Task.Yield();
             // 在 NET45 没有 ConnectAsync 方法
-            namedPipeClientStream.Connect();
+            await Task.Run(namedPipeClientStream.Connect);
 #endif
 
             NamedPipeClientStream = namedPipeClientStream;

--- a/src/dotnetCampus.Ipc.PipeCore/Core_/IpcPipeServerMessageProvider.cs
+++ b/src/dotnetCampus.Ipc.PipeCore/Core_/IpcPipeServerMessageProvider.cs
@@ -34,7 +34,18 @@ namespace dotnetCampus.Ipc.PipeCore
 
         public async Task Start()
         {
-            var namedPipeServerStream = new NamedPipeServerStream(PipeName, PipeDirection.InOut, 250);
+            var namedPipeServerStream = new NamedPipeServerStream
+            (
+                PipeName,
+                // 本框架使用两个半工做双向通讯，因此这里只是接收，不做发送
+                PipeDirection.In,
+                // 旧框架采用默认为 260 个实例链接，这里减少 10 个，没有具体的理由，待测试
+                250,
+                // 默认都采用 byte 方式
+                PipeTransmissionMode.Byte,
+                // 采用异步的方式。如果没有设置，默认是同步方式，即使有 Async 的方法，底层也是走同步
+                PipeOptions.Asynchronous
+            );
             NamedPipeServerStream = namedPipeServerStream;
 
 #if NETCOREAPP
@@ -43,7 +54,6 @@ namespace dotnetCampus.Ipc.PipeCore
             await Task.Factory.FromAsync(namedPipeServerStream.BeginWaitForConnection,
                 namedPipeServerStream.EndWaitForConnection, null);
 #endif
-
 
             //var streamMessageConverter = new StreamMessageConverter(namedPipeServerStream,
             //    IpcConfiguration.MessageHeader, IpcConfiguration.SharedArrayPool);


### PR DESCRIPTION
之前在主线程调用了 Connect 方法，而让主线程卡。即使前面加了 Task.Yield 方法，但逗比没有切线程