### PR TITLE
将项目中不统一的缩进进行统一

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,8 +6,10 @@ insert_final_newline = true
 tab_width = 4
 trim_trailing_whitespace = true
 
-[*.xml]
+[*.{xml,csproj,vbproj,props,targets}]
+indent_size =2
 indent_style = space
+tab_width =2
 
 [*.{cs,vb}]
 dotnet_sort_system_directives_first = true

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,10 +1,10 @@
-<Project>
+﻿<Project>
   <Import Project="build\Version.props" />
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <PackageOutputPath>$(MSBuildThisFileDirectory)bin\$(Configuration)</PackageOutputPath>
     <Company>dotnet campus（.NET 职业技术学院）</Company>
- 
+
     <!-- 替换下面信息 -->
     <Authors>dotnet-campus</Authors>
     <RepositoryUrl>https://github.com/dotnet-campus/dotnetCampus.Ipc</RepositoryUrl>
@@ -12,7 +12,7 @@
     <Description>TODO: 请在此处添加包描述信息。</Description>
 
     <RepositoryType>git</RepositoryType>
-    <Copyright>Copyright © 2020 dotnet campus, All Rights Reserved.</Copyright> 
+    <Copyright>Copyright © 2020 dotnet campus, All Rights Reserved.</Copyright>
   </PropertyGroup>
 
   <ItemGroup>

--- a/demo/dotnetCampus.Ipc.Demo/dotnetCampus.Ipc.Demo.csproj
+++ b/demo/dotnetCampus.Ipc.Demo/dotnetCampus.Ipc.Demo.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-        <Nullable>enable</Nullable>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <Nullable>enable</Nullable>
 
-        <IsPackable>false</IsPackable>
-    </PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\..\src\dotnetCampus.Ipc\dotnetCampus.Ipc.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\dotnetCampus.Ipc\dotnetCampus.Ipc.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/PipeMvc/dotnetCampus.Ipc.PipeMvcClient/dotnetCampus.Ipc.PipeMvcClient.csproj
+++ b/src/PipeMvc/dotnetCampus.Ipc.PipeMvcClient/dotnetCampus.Ipc.PipeMvcClient.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <Nullable>enable</Nullable>
-        <IsPackable>true</IsPackable>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Nullable>enable</Nullable>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\..\dotnetCampus.Ipc\dotnetCampus.Ipc.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\dotnetCampus.Ipc\dotnetCampus.Ipc.csproj" />
+  </ItemGroup>
 
-    <Import Project="..\dotnetCampus.Ipc.PipeMvcShare\dotnetCampus.Ipc.PipeMvcShare.projitems" Label="Shared" />
+  <Import Project="..\dotnetCampus.Ipc.PipeMvcShare\dotnetCampus.Ipc.PipeMvcShare.projitems" Label="Shared" />
 
 </Project>

--- a/src/PipeMvc/dotnetCampus.Ipc.PipeMvcServer/Properties/launchSettings.json
+++ b/src/PipeMvc/dotnetCampus.Ipc.PipeMvcServer/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:57002/",
+      "sslPort": 44362
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "dotnetCampus.Ipc.PipeMvcServer": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:5001;http://localhost:5000"
+    }
+  }
+}

--- a/src/dotnetCampus.Ipc/dotnetCampus.Ipc.csproj
+++ b/src/dotnetCampus.Ipc/dotnetCampus.Ipc.csproj
@@ -1,47 +1,47 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;net45</TargetFrameworks>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <Nullable>enable</Nullable>
-        <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net45</TargetFrameworks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Nullable>enable</Nullable>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+  </PropertyGroup>
 
-    <!-- 在 GitHub 的 Action 构建会添加 GITHUB_ACTIONS 变量 -->
-    <!-- 下面进行自动构建，自动添加源代码链接等 -->
-    <!-- 详细请看 https://github.com/dotnet/sourcelink -->
-    <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-        <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  <!-- 在 GitHub 的 Action 构建会添加 GITHUB_ACTIONS 变量 -->
+  <!-- 下面进行自动构建，自动添加源代码链接等 -->
+  <!-- 详细请看 https://github.com/dotnet/sourcelink -->
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
 
-        <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
-        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
 
-        <!-- 只有在 GitHub 的 Action 构建才能使用源代码链接 -->
-        <!-- 源代码链接需要使用 commit 号，而在 GitHub 的 Action 构建的 commit 才是对的 -->
-        <!-- 本地构建，也许没有记得 commit 就构建，此时的 nuget 包的源代码是不对的，上传上去会让调试诡异 -->
-        <!-- Optional: Embed source files that are not tracked by the source control manager in the PDB -->
-        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <!-- 只有在 GitHub 的 Action 构建才能使用源代码链接 -->
+    <!-- 源代码链接需要使用 commit 号，而在 GitHub 的 Action 构建的 commit 才是对的 -->
+    <!-- 本地构建，也许没有记得 commit 就构建，此时的 nuget 包的源代码是不对的，上传上去会让调试诡异 -->
+    <!-- Optional: Embed source files that are not tracked by the source control manager in the PDB -->
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
 
-        <!-- 本地等不需要创建符号文件 -->
-        <!-- Optional: Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
-        <IncludeSymbols>true</IncludeSymbols>
-        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    </PropertyGroup>
-    <ItemGroup>
-        <Compile Include="..\..\tests\dotnetCampus.Ipc.Tests\Attributes.cs" Link="Properties\Attributes.cs" />
-    </ItemGroup>
+    <!-- 本地等不需要创建符号文件 -->
+    <!-- Optional: Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\..\tests\dotnetCampus.Ipc.Tests\Attributes.cs" Link="Properties\Attributes.cs" />
+  </ItemGroup>
 
-    <ItemGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-        <!-- 链接源代码到 GitHub 仓库，方便调试 -->
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    </ItemGroup>
+  <ItemGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <!-- 链接源代码到 GitHub 仓库，方便调试 -->
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Walterlv.NullableAttributes.Source" Version="7.0.1" PrivateAssets="all" />
-        <PackageReference Include="dotnetCampus.AsyncWorkerCollection.Source" Version="1.6.4" />
-        <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-        <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-        <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Walterlv.NullableAttributes.Source" Version="7.0.1" PrivateAssets="all" />
+    <PackageReference Include="dotnetCampus.AsyncWorkerCollection.Source" Version="1.6.4" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+  </ItemGroup>
 
 </Project>

--- a/tests/dotnetCampus.Ipc.Tests/dotnetCampus.Ipc.Tests.csproj
+++ b/tests/dotnetCampus.Ipc.Tests/dotnetCampus.Ipc.Tests.csproj
@@ -1,22 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
-        <IsPackable>false</IsPackable>
-    </PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-        <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
-        <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
-        <PackageReference Include="coverlet.collector" Version="1.3.0" />
-        <PackageReference Include="Moq" Version="4.14.6" />
-        <PackageReference Include="MSTestEnhancer" Version="2.0.1" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
+    <PackageReference Include="coverlet.collector" Version="1.3.0" />
+    <PackageReference Include="Moq" Version="4.14.6" />
+    <PackageReference Include="MSTestEnhancer" Version="2.0.1" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\..\src\dotnetCampus.Ipc\dotnetCampus.Ipc.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\dotnetCampus.Ipc\dotnetCampus.Ipc.csproj" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
无论你是新建一个什么样的项目，Visual Studio 提供的模板对 csproj/vbproj/shproj/props/targets 的缩进都是 2。如果你强行将其设为 4，会导致每次新建项目完后需要专门针对你的格式再手工调一遍。即使是机器人调也会导致出现一个专门的格式调整，这很没有必要。