### PR TITLE
废弃对 ByteListMessageStream 的内存回收策略，原因是回收的对象可能依然被其他模块占用

### DIFF
--- a/src/dotnetCampus.Ipc/Utils/IO/ByteListMessageStream.cs
+++ b/src/dotnetCampus.Ipc/Utils/IO/ByteListMessageStream.cs
@@ -5,27 +5,19 @@ using dotnetCampus.Ipc.Utils.Buffers;
 
 namespace dotnetCampus.Ipc.Utils.IO
 {
+    /// <summary>
+    /// 数组列表的消息，特别定义类型，方便内存分析
+    /// </summary>
     internal class ByteListMessageStream : MemoryStream
     {
-        public ByteListMessageStream(byte[] buffer, int count, ISharedArrayPool sharedArrayPool) : base(buffer, 0,
+        public ByteListMessageStream(byte[] buffer, int count) : base(buffer, 0,
             count, false)
         {
-            _sharedArrayPool = sharedArrayPool;
-            Buffer = buffer;
         }
 
         public ByteListMessageStream(in IpcMessageContext ipcMessageContext) : this(ipcMessageContext.MessageBuffer,
-            (int) ipcMessageContext.MessageLength, ipcMessageContext.SharedArrayPool)
+            (int) ipcMessageContext.MessageLength)
         {
         }
-
-        ~ByteListMessageStream()
-        {
-            _sharedArrayPool.Return(Buffer);
-        }
-
-        private byte[] Buffer { get; }
-
-        private readonly ISharedArrayPool _sharedArrayPool;
     }
 }


### PR DESCRIPTION
因为此对象是作为事件对外传输的，对外是业务，在业务端有诡异的逻辑依然拿到 byte 数组引用