### PR TITLE
Fix some unusual exceptions of the IPCs

### DIFF
--- a/src/dotnetCampus.Ipc/Internals/IpcPipeServerMessageProvider.cs
+++ b/src/dotnetCampus.Ipc/Internals/IpcPipeServerMessageProvider.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO;
 using System.IO.Pipes;
 using System.Threading.Tasks;
 
 using dotnetCampus.Ipc.Context;
 using dotnetCampus.Ipc.Pipes;
+using dotnetCampus.Ipc.Utils.Extensions;
 
 namespace dotnetCampus.Ipc.Internals
 {
@@ -60,10 +62,16 @@ namespace dotnetCampus.Ipc.Internals
                 namedPipeServerStream.EndWaitForConnection, null).ConfigureAwait(false);
 #endif
             }
-            catch (IOException e)
+            catch (IOException ex)
             {
                 // "管道已结束。"
                 // 当前服务关闭，此时异常符合预期
+                return;
+            }
+            catch (ObjectDisposedException ex)
+            {
+                // 当等待客户端连上此服务端期间，被调用了 Dispose 方法后，会抛出此异常。
+                // 日志在 Dispose 方法里记。
                 return;
             }
             //var streamMessageConverter = new StreamMessageConverter(namedPipeServerStream,
@@ -107,16 +115,25 @@ namespace dotnetCampus.Ipc.Internals
 
         public void Dispose()
         {
-            if (ServerStreamMessageReader is null)
+            try
             {
-                // 证明此时还没完全连接
-                NamedPipeServerStream.Dispose();
+                if (ServerStreamMessageReader is null)
+                {
+                    // 证明此时还没完全连接
+                    NamedPipeServerStream.Dispose();
+                }
+                else
+                {
+                    // 证明已连接完成，此时不需要释放 NamedPipeServerStream 类
+                    // 不在这一层释放 NamedPipeServerStream 类
+                    ServerStreamMessageReader.Dispose();
+                }
             }
-            else
+            finally
             {
-                // 证明已连接完成，此时不需要释放 NamedPipeServerStream 类
-                // 不在这一层释放 NamedPipeServerStream 类
-                ServerStreamMessageReader.Dispose();
+                // 通过查看 Dispose 的堆栈来检查出异常时到底是谁在 Dispose。
+                IpcContext.Logger.Warning(@$"IpcPipeServerMessageProvider.Dispose
+{new StackTrace()}");
             }
         }
     }

--- a/src/dotnetCampus.Ipc/Internals/PeerReConnector.cs
+++ b/src/dotnetCampus.Ipc/Internals/PeerReConnector.cs
@@ -1,4 +1,7 @@
-﻿using dotnetCampus.Ipc.Context;
+﻿using System.IO;
+using System.Threading.Tasks;
+
+using dotnetCampus.Ipc.Context;
 using dotnetCampus.Ipc.Pipes;
 
 namespace dotnetCampus.Ipc.Internals
@@ -27,7 +30,38 @@ namespace dotnetCampus.Ipc.Internals
         private async void Reconnect()
         {
             var ipcClientService = _ipcProvider.CreateIpcClientService(_peerProxy.PeerName);
-            await ipcClientService.Start();
+            for (int i = 0; i < 4; i++)
+            {
+                try
+                {
+                    await ipcClientService.Start();
+                    break;
+                }
+                catch (FileNotFoundException ex)
+                {
+                    // ## 此异常有两种
+                    //
+                    //  1. 一种来自于 namedPipeClientStream.ConnectAsync()，刚调用时还能获取到管道句柄，但马上与之连接时便已断开。
+                    //  2. 另一种来自 RegisterToPeer()，前面已经连上了，但试图发消息时便已断开。
+                    //
+                    // ## 然而，为什么一连上就断开了呢？
+                    //
+                    // 这是因为每个端有两条管道，各自作为服务端和客户端。
+                    // 当重连时，靠的是服务端管道读到末尾来判断的；但此时重连的却是客户端。
+                    // 有极少情况下，这两条的断开时间间隔足够长到本方法的客户端已开始重连。
+                    // 那么，本方法的客户端在一开始试图连接对方时连上了，但随即就完成了之前没完成的断开，于是出现 FileNotFoundException。
+                    //
+                    // ## 那么，如何解决呢？
+                    //
+                    // 通过重连，我们可以缓解因对方正在断开导致的我们误连。通过重连多次，可以更大概率缓解以至于解决此异常。
+                    //
+                    // ## 是否有后续问题？
+                    //
+                    // 有可能本方法已全部完成之后才断开吗？不可能，因为 RegisterToPeer() 会发消息的，如果是对方进程退出等原因导致的断连，那么消息根本就无法发送。
+                    // 因为本调用内会置一个 TaskCompleteSource，所以也会导致一起等待此任务的其他发送全部失败，而解决方法就是在其他发送处也重试。
+                    await Task.Delay(16);
+                }
+            }
             _peerProxy.Reconnect(ipcClientService);
         }
     }

--- a/src/dotnetCampus.Ipc/Pipes/IpcClientService.cs
+++ b/src/dotnetCampus.Ipc/Pipes/IpcClientService.cs
@@ -10,6 +10,7 @@ using dotnetCampus.Ipc.Context;
 using dotnetCampus.Ipc.Diagnostics;
 using dotnetCampus.Ipc.Internals;
 using dotnetCampus.Ipc.Messages;
+using dotnetCampus.Ipc.Utils;
 using dotnetCampus.Ipc.Utils.Extensions;
 using dotnetCampus.Ipc.Utils.Logging;
 using dotnetCampus.Threading;
@@ -85,29 +86,12 @@ namespace dotnetCampus.Ipc.Pipes
                 PipeOptions.None, TokenImpersonationLevel.Impersonation);
             _namedPipeClientStreamTaskCompletionSource = new TaskCompletionSource<NamedPipeClientStream>();
 
-            // 带有重试的连接。
-            for (int i = 0; i < 4; i++)
-            {
-                try
-                {
 #if NETCOREAPP
-                    await namedPipeClientStream.ConnectAsync();
+            await namedPipeClientStream.ConnectAsync();
 #else
-                    // 在 NET45 没有 ConnectAsync 方法
-                    await Task.Run(namedPipeClientStream.Connect);
+            // 在 NET45 没有 ConnectAsync 方法
+            await Task.Run(namedPipeClientStream.Connect);
 #endif
-                    break;
-                }
-                catch (FileNotFoundException ex)
-                {
-                    // 因为每个端有两条管道，各自作为服务端和客户端。
-                    // 当重连时，靠的是服务端管道读到末尾来判断的；但此时重连的却是客户端。
-                    // 有极少情况下，这两条的断开时间间隔足够长到本方法的客户端已开始重连。
-                    // 那么，本方法的客户端在一开始试图连接对方时连上了，但随即就完成了之前没完成的断开，于是出现 FileNotFoundException。
-                    // 这时，我们通过重新连接一次可以再次等对方重新启动完再连。
-                    await Task.Delay(16);
-                }
-            }
 
             if (!_namedPipeClientStreamTaskCompletionSource.Task.IsCompleted)
             {


### PR DESCRIPTION
```csharp
exName: System.ObjectDisposedException; 
exMessage: Cannot access a closed pipe.; 
exStackTrace:    at System.IO.__Error.PipeNotOpen()
   at System.IO.Pipes.NamedPipeServerStream.CheckConnectOperationsServer()
   at System.IO.Pipes.NamedPipeServerStream.EndWaitForConnection(IAsyncResult asyncResult)
   at System.Threading.Tasks.TaskFactory`1.FromAsyncCoreLogic(IAsyncResult iar, Func`2 endFunction, Action`1 endAction, Task`1 promise, Boolean requiresSynchronization)
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at dotnetCampus.Ipc.Internals.IpcPipeServerMessageProvider.<Start>d__15.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at dotnetCampus.Ipc.Pipes.IpcServerService.<Start>d__9.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at dotnetCampus.Ipc.Pipes.IpcProvider.<StartServer>d__12.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.<>c.<ThrowAsync>b__6_1(Object state)
   at System.Threading.QueueUserWorkItemCallback.WaitCallback_Context(Object state)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.QueueUserWorkItemCallback.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem()
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading._ThreadPoolWaitCallback.PerformWaitCallback(); 
```

```csharp
exName: System.IO.FileNotFoundException; 
exMessage: 无法找到指定文件。; 
exStackTrace:    在 System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   在 System.IO.Pipes.NamedPipeClientStream.Connect(Int32 timeout)
   在 System.IO.Pipes.NamedPipeClientStream.Connect()
   在 System.Threading.Tasks.Task.InnerInvoke()
   在 System.Threading.Tasks.Task.Execute()
--- 引发异常的上一位置中堆栈跟踪的末尾 ---
   在 System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   在 System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   在 dotnetCampus.Ipc.Pipes.IpcClientService.<Start>d__19.MoveNext()
--- 引发异常的上一位置中堆栈跟踪的末尾 ---
   在 System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   在 System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   在 dotnetCampus.Ipc.Internals.PeerReConnector.<Reconnect>d__4.MoveNext()
--- 引发异常的上一位置中堆栈跟踪的末尾 ---
   在 System.Runtime.CompilerServices.AsyncMethodBuilderCore.<>c.<ThrowAsync>b__6_1(Object state)
   在 System.Threading.QueueUserWorkItemCallback.WaitCallback_Context(Object state)
   在 System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   在 System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   在 System.Threading.QueueUserWorkItemCallback.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem()
   在 System.Threading.ThreadPoolWorkQueue.Dispatch()
   在 System.Threading._ThreadPoolWaitCallback.PerformWaitCallback(); 
```

```csharp
exName: System.IO.IOException; 
exMessage: Pipe is broken.; 
exStackTrace:    at System.IO.Pipes.PipeStream.WinIOError(Int32 errorCode)
   at System.IO.Pipes.PipeStream.WriteCore(Byte[] buffer, Int32 offset, Int32 count)
   at System.IO.Pipes.PipeStream.Write(Byte[] buffer, Int32 offset, Int32 count)
   at System.IO.Stream.<BeginWriteInternal>b__11(Object param0)
   at System.Threading.Tasks.Task`1.InnerInvoke()
   at System.Threading.Tasks.Task.Execute()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.IO.Stream.EndWrite(IAsyncResult asyncResult)
   at System.IO.Pipes.PipeStream.EndWrite(IAsyncResult asyncResult)
   at System.IO.Stream.<BeginEndWriteAsync>b__17(Stream stream, IAsyncResult asyncResult)
   at System.Threading.Tasks.TaskFactory`1.FromAsyncTrimPromise`1.Complete(TInstance thisRef, Func`3 endMethod, IAsyncResult asyncResult, Boolean requiresSynchronization)
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at dotnetCampus.Ipc.Utils.IO.AsyncBinaryWriter.<WriteAsync>d__4.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at dotnetCampus.Ipc.Internals.IpcMessageConverter.<WriteHeaderAsync>d__3.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at dotnetCampus.Ipc.Internals.IpcMessageConverter.<WriteAsync>d__0.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at dotnetCampus.Ipc.Pipes.IpcClientService.<>c__DisplayClass22_0.<<WriteMessageAsync>g__WriteMessageAsyncInner|0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at dotnetCampus.Ipc.Utils.Extensions.DoubleBufferTaskExtensions.<>c__DisplayClass1_0.<<AddTaskAsync>b__0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at dotnetCampus.Ipc.Utils.Extensions.DoubleBufferTaskExtensions.<AddTaskAsync>d__1.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at dotnetCampus.Ipc.Pipes.IpcClientService.<WriteMessageAsync>d__22.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at dotnetCampus.Ipc.Pipes.IpcClientService.<RegisterToPeer>d__20.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at dotnetCampus.Ipc.Pipes.IpcClientService.<Start>d__19.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at dotnetCampus.Ipc.Internals.PeerReConnector.<Reconnect>d__4.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.<ThrowAsync>b__1(Object state)
   at System.Threading.QueueUserWorkItemCallback.WaitCallback_Context(Object state)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.ExecutionContext.Run(ExecutionContext executionContext, ContextCallback callback, Object state, Boolean preserveSyncCtx)
   at System.Threading.QueueUserWorkItemCallback.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem()
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading._ThreadPoolWaitCallback.PerformWaitCallback(); 
```
