### PR TITLE
修复业务端设置 Ipc 管道客户端不支持重新连接 在设置自动重连时后台线程抛出异常

### DIFF
--- a/src/dotnetCampus.Ipc/Context/IpcConfiguration.cs
+++ b/src/dotnetCampus.Ipc/Context/IpcConfiguration.cs
@@ -15,7 +15,7 @@ namespace dotnetCampus.Ipc.Context
     public class IpcConfiguration
     {
         /// <summary>
-        /// 自动重连 Peer 是否开启，如开启，在断开后将会自动尝试去重新连接。推荐设置为 true 时，同时设置 <see cref="IpcClientPipeConnector"/> 属性，以解决无限重试
+        /// 自动重连 Peer 是否开启，如开启，在断开后将会自动尝试去重新连接。设置为 true 时，推荐同时设置 <see cref="IpcClientPipeConnector"/> 属性，以防无限重试。
         /// </summary>
         public bool AutoReconnectPeers { get; set; } = false;
 

--- a/src/dotnetCampus.Ipc/Context/IpcConfiguration.cs
+++ b/src/dotnetCampus.Ipc/Context/IpcConfiguration.cs
@@ -15,7 +15,7 @@ namespace dotnetCampus.Ipc.Context
     public class IpcConfiguration
     {
         /// <summary>
-        /// 自动重连 Peer 是否开启，如开启，在断开后将会自动尝试去重新连接
+        /// 自动重连 Peer 是否开启，如开启，在断开后将会自动尝试去重新连接。推荐设置为 true 时，同时设置 <see cref="IpcClientPipeConnector"/> 属性，以解决无限重试
         /// </summary>
         public bool AutoReconnectPeers { get; set; } = false;
 

--- a/src/dotnetCampus.Ipc/Internals/PeerReConnector.cs
+++ b/src/dotnetCampus.Ipc/Internals/PeerReConnector.cs
@@ -41,7 +41,7 @@ namespace dotnetCampus.Ipc.Internals
             }
             else
             {
-                _ipcProvider.IpcContext.Logger.Error($"[PeerReConnector][Reconnect] Fail");
+                _ipcProvider.IpcContext.Logger.Error($"[PeerReConnector][Reconnect] Fail. PeerName={_peerProxy.PeerName}");
             }
         }
 

--- a/src/dotnetCampus.Ipc/Internals/PeerReConnector.cs
+++ b/src/dotnetCampus.Ipc/Internals/PeerReConnector.cs
@@ -1,8 +1,11 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Threading.Tasks;
 
 using dotnetCampus.Ipc.Context;
+using dotnetCampus.Ipc.Exceptions;
 using dotnetCampus.Ipc.Pipes;
+using dotnetCampus.Ipc.Utils.Extensions;
 
 namespace dotnetCampus.Ipc.Internals
 {
@@ -30,12 +33,26 @@ namespace dotnetCampus.Ipc.Internals
         private async void Reconnect()
         {
             var ipcClientService = _ipcProvider.CreateIpcClientService(_peerProxy.PeerName);
+            var success = await TryReconnectAsync(ipcClientService);
+
+            if (success)
+            {
+                _peerProxy.Reconnect(ipcClientService);
+            }
+            else
+            {
+                _ipcProvider.IpcContext.Logger.Error($"[PeerReConnector][Reconnect] Fail");
+            }
+        }
+
+        private async Task<bool> TryReconnectAsync(IpcClientService ipcClientService)
+        {
             for (int i = 0; i < 16; i++)
             {
                 try
                 {
                     await ipcClientService.Start();
-                    break;
+                    return true;
                 }
                 // ## 此异常有两种
                 catch (FileNotFoundException)
@@ -47,6 +64,19 @@ namespace dotnetCampus.Ipc.Internals
                 {
                     // 2. 另一种来自 RegisterToPeer()，前面已经连上了，但试图发消息时便已断开。
                     await Task.Delay(16);
+                }
+                catch (IpcClientPipeConnectionException exception)
+                {
+                    // 业务层判断不能重新连接了，必定失败
+                    // 返回就可以了
+                    _ipcProvider.IpcContext.Logger.Error($"[PeerReConnector][Reconnect][IpcClientPipeConnectionException] {exception}");
+                    return false;
+                }
+                catch (Exception exception)
+                {
+                    // 未知的异常，不再继续
+                    _ipcProvider.IpcContext.Logger.Error($"[PeerReConnector][Reconnect]{exception}");
+                    return false;
                 }
                 // ## 然而，为什么一连上就断开了呢？
                 //
@@ -64,8 +94,8 @@ namespace dotnetCampus.Ipc.Internals
                 // 有可能本方法已全部完成之后才断开吗？不可能，因为 RegisterToPeer() 会发消息的，如果是对方进程退出等原因导致的断连，那么消息根本就无法发送。
                 // 因为本调用内会置一个 TaskCompleteSource，所以也会导致一起等待此任务的其他发送全部失败，而解决方法就是在其他发送处也重试。
             }
-            // 实在没办法连上，就抛异常吧。
-            _peerProxy.Reconnect(ipcClientService);
+
+            return false;
         }
     }
 }

--- a/tests/dotnetCampus.Ipc.Tests/Pipes/PipeConnectors/IpcClientPipeConnectorTest.cs
+++ b/tests/dotnetCampus.Ipc.Tests/Pipes/PipeConnectors/IpcClientPipeConnectorTest.cs
@@ -18,7 +18,7 @@ namespace dotnetCampus.Ipc.Tests.Pipes.PipeConnectors
         [ContractTestCase]
         public void ReConnectBreak()
         {
-            "重连接时，调用 CanContinue 方法返回不支持再次重新连接，".Test(async () =>
+            "重连接时，调用 CanContinue 方法返回不支持再次重新连接，则不再次重新连接".Test(async () =>
             {
                 int callCanContinueCount = 0;
                 var asyncAutoResetEvent = new AsyncAutoResetEvent(false);

--- a/tests/dotnetCampus.Ipc.Tests/Pipes/PipeConnectors/IpcClientPipeConnectorTest.cs
+++ b/tests/dotnetCampus.Ipc.Tests/Pipes/PipeConnectors/IpcClientPipeConnectorTest.cs
@@ -1,10 +1,11 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 using dotnetCampus.Ipc.Context;
 using dotnetCampus.Ipc.Exceptions;
 using dotnetCampus.Ipc.Pipes;
 using dotnetCampus.Ipc.Pipes.PipeConnectors;
-
+using dotnetCampus.Threading;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using MSTest.Extensions.Contracts;
@@ -14,6 +15,44 @@ namespace dotnetCampus.Ipc.Tests.Pipes.PipeConnectors
     [TestClass]
     public class IpcClientPipeConnectorTest
     {
+        [ContractTestCase]
+        public void ReConnectBreak()
+        {
+            "重连接时，调用 CanContinue 方法返回不支持再次重新连接，".Test(async () =>
+            {
+                int callCanContinueCount = 0;
+                var asyncAutoResetEvent = new AsyncAutoResetEvent(false);
+                var ipcConfiguration = new IpcConfiguration()
+                {
+                    AutoReconnectPeers = true,
+                    IpcClientPipeConnector = new IpcClientPipeConnector(c =>
+                    {
+                        // 调用 CanContinue 方法返回不支持
+                        callCanContinueCount++;
+                        asyncAutoResetEvent.Set();
+                        return false;
+                    }, stepTimeout: TimeSpan.FromMilliseconds(100)),
+                };
+
+                var ipcProviderA = new IpcProvider(Guid.NewGuid().ToString("N"), ipcConfiguration);
+                var ipcProviderB = new IpcProvider();
+                ipcProviderA.StartServer();
+                ipcProviderB.StartServer();
+
+                var peer = await ipcProviderA.GetAndConnectToPeerAsync(ipcProviderB.IpcContext.PipeName);
+                Assert.AreEqual(0, callCanContinueCount);
+                Assert.IsNotNull(peer);
+
+                // 断开，预期此时将会重新连接
+                ipcProviderB.Dispose();
+
+                await asyncAutoResetEvent.WaitOneAsync();
+                await Task.Delay(TimeSpan.FromSeconds(1));
+                Assert.AreEqual(true, peer.IsBroken);
+                Assert.AreEqual(1, callCanContinueCount);
+            });
+        }
+
         [ContractTestCase]
         public void ConnectNamedPipeAsync()
         {


### PR DESCRIPTION
自动重连时，如果业务端设置 Ipc 管道客户端不支持重新连接，那就不能继续循环尝试重新连接的逻辑