### PR TITLE
修复逗比问题让读取空跑

### DIFF
--- a/src/dotnetCampus.Ipc/Internals/IpcMessageConverter.cs
+++ b/src/dotnetCampus.Ipc/Internals/IpcMessageConverter.cs
@@ -180,7 +180,13 @@ namespace dotnetCampus.Ipc.Internals
 
             var messageBuffer = sharedArrayPool.Rent((int) messageLength);
             // byte[] Content        实际的内容
-            var readCount = await ReadBufferAsync(stream, messageBuffer, (int) messageLength);
+            var readCountResult = await ReadBufferAsync(stream, messageBuffer, (int) messageLength);
+            if (readCountResult.IsEndOfStream)
+            {
+                return StreamReadResult<IpcMessageResult>.EndOfStream;
+            }
+
+            var readCount = readCountResult.Result;
 
             Debug.Assert(readCount == messageLength);
 
@@ -188,17 +194,23 @@ namespace dotnetCampus.Ipc.Internals
             return new StreamReadResult<IpcMessageResult>(new IpcMessageResult(success: true, ipcMessageContext, commandType));
         }
 
-        private static async Task<int> ReadBufferAsync(Stream stream, byte[] messageBuffer, int messageLength)
+        private static async Task<StreamReadResult<int>> ReadBufferAsync(Stream stream, byte[] messageBuffer, int messageLength)
         {
             var readCount = 0;
 
             do
             {
                 var n = await stream.ReadAsync(messageBuffer, readCount, messageLength - readCount);
+
+                if (n == 0)
+                {
+                    return StreamReadResult<int>.EndOfStream;
+                }
+
                 readCount += n;
             } while (readCount < messageLength);
 
-            return readCount;
+            return new StreamReadResult<int>(readCount);
         }
 
         private static async Task<StreamReadResult<bool>> GetHeader(Stream stream, byte[] messageHeader, ISharedArrayPool sharedArrayPool)
@@ -223,7 +235,14 @@ namespace dotnetCampus.Ipc.Internals
 
             try
             {
-                var readCount = await ReadBufferAsync(stream, messageHeaderBuffer, messageHeader.Length);
+                var readCountResult = await ReadBufferAsync(stream, messageHeaderBuffer, messageHeader.Length);
+                if (readCountResult.IsEndOfStream)
+                {
+                    return StreamReadResult<bool>.EndOfStream;
+                }
+
+                var readCount = readCountResult.Result;
+
                 Debug.Assert(readCount == messageHeader.Length);
                 if (ByteListExtensions.Equals(messageHeaderBuffer, messageHeader, readCount))
                 {


### PR DESCRIPTION
将会占用大量 CPU 进行空跑，原因是之前是抛出异常，为了减少异常修改为返回值，但是没有将所有读取进行修改，于是不断读取到 0 的值，不断循环