### PR TITLE
强行指定 6.0.0 版本用来修复降低版本无法构建

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -16,10 +16,14 @@ jobs:
         dotnet-version: |
           3.1.x
           5.0.x
-          6.0.x
+          6.0.100
 
-    - name: Build with dotnet
+    - name: Build
       run: dotnet build --configuration Release
 
     - name: Test
       run: dotnet test --configuration Release
+
+    - name: Pack
+      run: dotnet pack --configuration Release --no-build
+       

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -21,7 +21,7 @@ jobs:
           dotnet-version: |
             3.1.x
             5.0.x
-            6.0.x
+            6.0.100
 
       - name: Install dotnetCampus.EncodingNormalior
         run: dotnet tool update -g dotnetCampus.EncodingNormalior

--- a/.github/workflows/nuget-tag-publish.yml
+++ b/.github/workflows/nuget-tag-publish.yml
@@ -19,7 +19,7 @@ jobs:
         dotnet-version: |
           3.1.x
           5.0.x
-          6.0.x
+          6.0.100
 
     - name: Install dotnet tool
       run: dotnet tool install -g dotnetCampus.TagToVersion


### PR DESCRIPTION
修复 CS1705 错误，内部项目不敢追新使用新版本的 .NET SDK 和 .NET Runtime 因此将会因为产品项目的构建 SDK 低于此库发布时采用的 SDK 而失败

https://github.com/dotnet-campus/dotnetCampus.WindowsAPICodePack/pull/3