### PR TITLE
修复 对象数组作为参数时，代码生成器 空指针异常 

### DIFF
--- a/src/dotnetCampus.Ipc.Analyzers/SourceGenerators/Models/SourceTextBuilder.cs
+++ b/src/dotnetCampus.Ipc.Analyzers/SourceGenerators/Models/SourceTextBuilder.cs
@@ -34,7 +34,11 @@ internal class SourceTextBuilder
     public string SimplifyNameByAddUsing(ITypeSymbol typeSymbol)
     {
         var originalName = typeSymbol.ToString();
-        var @namespace = typeSymbol.ContainingNamespace.ToString();
+        var @namespace = typeSymbol.ContainingNamespace?.ToString();
+        if (@namespace == null)
+        {
+            return originalName;
+        }
         if (originalName.StartsWith(@namespace, StringComparison.Ordinal))
         {
             // 常规类型，“命名空间.类名”型。


### PR DESCRIPTION
Fix [106](https://github.com/dotnet-campus/dotnetCampus.Ipc/issues/106).