### PR TITLE
支持自定义线程模型 修复自动重连

### DIFF
--- a/src/dotnetCampus.Ipc/Context/IpcConfiguration.cs
+++ b/src/dotnetCampus.Ipc/Context/IpcConfiguration.cs
@@ -40,7 +40,7 @@ namespace dotnetCampus.Ipc.Context
         public IpcTaskScheduling IpcTaskScheduling { get; set; }
 
         /// <summary>
-        /// xxx
+        /// 添加自定义的 IPC 线程池。此属性一旦设置，将会让 <see cref="IpcTaskScheduling"/> 被无效掉
         /// </summary>
         public CustomIpcThreadPoolBase? CustomIpcThreadPool { set; get; }
 

--- a/src/dotnetCampus.Ipc/Context/IpcConfiguration.cs
+++ b/src/dotnetCampus.Ipc/Context/IpcConfiguration.cs
@@ -40,6 +40,11 @@ namespace dotnetCampus.Ipc.Context
         public IpcTaskScheduling IpcTaskScheduling { get; set; }
 
         /// <summary>
+        /// xxx
+        /// </summary>
+        public CustomIpcThreadPoolBase? CustomIpcThreadPool { set; get; }
+
+        /// <summary>
         /// 为 IPC 记录日志。
         /// </summary>
         public Func<string, IpcLogger>? IpcLoggerProvider { get; set; }

--- a/src/dotnetCampus.Ipc/Context/IpcContext.cs
+++ b/src/dotnetCampus.Ipc/Context/IpcContext.cs
@@ -39,11 +39,18 @@ namespace dotnetCampus.Ipc.Context
 
             IpcClientPipeConnector = IpcConfiguration.IpcClientPipeConnector;
 
-            TaskPool = IpcConfiguration.IpcTaskScheduling is IpcTaskScheduling.GlobalConcurrent
-                // 支持并发的 IPC 将共用同一个线程池。
-                ? DefaultIpcTask
-                // 要求在同一线程调度的 IPC 将近似独享一个“线程”。
-                : new IpcTask(new IpcSingleThreadPool());
+            if (IpcConfiguration.CustomIpcThreadPool is {} customIpcThreadPool)
+            {
+                TaskPool = new IpcTask(customIpcThreadPool);
+            }
+            else
+            {
+                TaskPool = IpcConfiguration.IpcTaskScheduling is IpcTaskScheduling.GlobalConcurrent
+                    // 支持并发的 IPC 将共用同一个线程池。
+                    ? DefaultIpcTask
+                    // 要求在同一线程调度的 IPC 将近似独享一个“线程”。
+                    : new IpcTask(new IpcSingleThreadPool());
+            }
 
             Logger = IpcConfiguration.IpcLoggerProvider?.Invoke(pipeName) ?? new IpcLogger(pipeName);
         }

--- a/src/dotnetCampus.Ipc/Exceptions/IpcClientPipeConnectionException.cs
+++ b/src/dotnetCampus.Ipc/Exceptions/IpcClientPipeConnectionException.cs
@@ -1,4 +1,6 @@
-﻿namespace dotnetCampus.Ipc.Exceptions;
+﻿using System;
+
+namespace dotnetCampus.Ipc.Exceptions;
 
 /// <summary>
 /// IPC的客户端连接失败异常
@@ -10,12 +12,16 @@ public class IpcClientPipeConnectionException : IpcRemoteException
     /// </summary>
     /// <param name="peerName">连接的服务名</param>
     /// <param name="message"></param>
-    public IpcClientPipeConnectionException(string peerName, string? message = null)
+    public IpcClientPipeConnectionException(string peerName, string? message = null) : this(peerName, null, message)
     {
-        PeerName = peerName;
-        _message = message;
     }
 
+    public IpcClientPipeConnectionException(string peerName, Exception? innerException, string? message = null) : base(message, innerException)
+    {
+        PeerName = peerName;
+        _message = message ?? innerException?.Message;
+    }
+    
     /// <inheritdoc />
     public override string Message => _message ?? $"连接管道服务失败。服务管道名:{PeerName}";
 

--- a/src/dotnetCampus.Ipc/Exceptions/IpcException.cs
+++ b/src/dotnetCampus.Ipc/Exceptions/IpcException.cs
@@ -27,7 +27,7 @@ namespace dotnetCampus.Ipc.Exceptions
         /// </summary>
         /// <param name="message">自定义消息。</param>
         /// <param name="innerException">内部异常。</param>
-        public IpcException(string message, Exception innerException) : base(message, innerException)
+        public IpcException(string? message, Exception? innerException) : base(message, innerException)
         {
         }
     }

--- a/src/dotnetCampus.Ipc/Exceptions/IpcRemoteException.cs
+++ b/src/dotnetCampus.Ipc/Exceptions/IpcRemoteException.cs
@@ -39,13 +39,13 @@ namespace dotnetCampus.Ipc.Exceptions
         /// </summary>
         /// <param name="message">自定义消息。</param>
         /// <param name="innerException">内部异常。</param>
-        public IpcRemoteException(string message, Exception innerException) : base(message, innerException)
+        public IpcRemoteException(string? message, Exception? innerException) : base(message, innerException)
         {
         }
 
         /// <summary>
         /// 远端出现异常时的调用堆栈。
         /// </summary>
-        public override string StackTrace => _remoteStackTrace ?? base.StackTrace;
+        public override string? StackTrace => _remoteStackTrace ?? base.StackTrace;
     }
 }

--- a/src/dotnetCampus.Ipc/Internals/PeerManager.cs
+++ b/src/dotnetCampus.Ipc/Internals/PeerManager.cs
@@ -78,7 +78,17 @@ namespace dotnetCampus.Ipc.Internals
             if (AutoReconnectPeers)
             {
                 peerProxy.PeerReConnector ??= new PeerReConnector(peerProxy, _ipcProvider);
+
+                peerProxy.PeerReConnector.ReconnectFail -= PeerReConnector_ReconnectFail;
+                peerProxy.PeerReConnector.ReconnectFail += PeerReConnector_ReconnectFail;
             }
+        }
+
+        private void PeerReConnector_ReconnectFail(object? sender, ReconnectFailEventArgs e)
+        {
+            // 重新连接失败，此时需要清理
+            // 如果不清理，将会导致过了一会，有新的连接进来，使用和上次需要重连相同的 PeerName 的不会再次触发事件
+            RemovePeerProxy(e.PeerProxy);
         }
 
         private bool AutoReconnectPeers => _ipcProvider.IpcServerService.IpcContext.IpcConfiguration.AutoReconnectPeers;
@@ -93,7 +103,6 @@ namespace dotnetCampus.Ipc.Internals
                 peer.DisposePeer();
             }
         }
-
 
         private ConcurrentDictionary<string, PeerProxy> ConnectedServerManagerList { get; } =
             new ConcurrentDictionary<string, PeerProxy>();

--- a/src/dotnetCampus.Ipc/Internals/PeerReConnector.cs
+++ b/src/dotnetCampus.Ipc/Internals/PeerReConnector.cs
@@ -30,6 +30,8 @@ namespace dotnetCampus.Ipc.Internals
         private readonly PeerProxy _peerProxy;
         private readonly IpcProvider _ipcProvider;
 
+        public event EventHandler<ReconnectFailEventArgs>? ReconnectFail;
+
         private async void Reconnect()
         {
             var ipcClientService = _ipcProvider.CreateIpcClientService(_peerProxy.PeerName);
@@ -42,6 +44,8 @@ namespace dotnetCampus.Ipc.Internals
             else
             {
                 _ipcProvider.IpcContext.Logger.Error($"[PeerReConnector][Reconnect] Fail. PeerName={_peerProxy.PeerName}");
+
+                ReconnectFail?.Invoke(this, new ReconnectFailEventArgs(_peerProxy, _ipcProvider);
             }
         }
 
@@ -97,5 +101,17 @@ namespace dotnetCampus.Ipc.Internals
 
             return false;
         }
+    }
+
+    class ReconnectFailEventArgs : EventArgs
+    {
+        public ReconnectFailEventArgs(PeerProxy peerProxy, IpcProvider ipcProvider)
+        {
+            PeerProxy = peerProxy;
+            IpcProvider = ipcProvider;
+        }
+
+        public PeerProxy PeerProxy { get; }
+        public IpcProvider IpcProvider { get; }
     }
 }

--- a/src/dotnetCampus.Ipc/Internals/PeerReConnector.cs
+++ b/src/dotnetCampus.Ipc/Internals/PeerReConnector.cs
@@ -45,7 +45,7 @@ namespace dotnetCampus.Ipc.Internals
             {
                 _ipcProvider.IpcContext.Logger.Error($"[PeerReConnector][Reconnect] Fail. PeerName={_peerProxy.PeerName}");
 
-                ReconnectFail?.Invoke(this, new ReconnectFailEventArgs(_peerProxy, _ipcProvider);
+                ReconnectFail?.Invoke(this, new ReconnectFailEventArgs(_peerProxy, _ipcProvider));
             }
         }
 

--- a/src/dotnetCampus.Ipc/Internals/PeerReConnector.cs
+++ b/src/dotnetCampus.Ipc/Internals/PeerReConnector.cs
@@ -55,8 +55,7 @@ namespace dotnetCampus.Ipc.Internals
             {
                 try
                 {
-                    await ipcClientService.Start();
-                    return true;
+                    return await ipcClientService.StartInternalAsync(isReConnect: true, shouldRegisterToPeer: true);
                 }
                 // ## 此异常有两种
                 catch (FileNotFoundException)
@@ -69,13 +68,14 @@ namespace dotnetCampus.Ipc.Internals
                     // 2. 另一种来自 RegisterToPeer()，前面已经连上了，但试图发消息时便已断开。
                     await Task.Delay(16);
                 }
-                catch (IpcClientPipeConnectionException exception)
-                {
-                    // 业务层判断不能重新连接了，必定失败
-                    // 返回就可以了
-                    _ipcProvider.IpcContext.Logger.Error($"[PeerReConnector][Reconnect][IpcClientPipeConnectionException] {exception}");
-                    return false;
-                }
+                // 不会出现此异常。原本是通过异常控制是否成功，才需要判断
+                //catch (IpcClientPipeConnectionException exception)
+                //{
+                //    // 业务层判断不能重新连接了，必定失败
+                //    // 返回就可以了
+                //    _ipcProvider.IpcContext.Logger.Error($"[PeerReConnector][Reconnect][IpcClientPipeConnectionException] {exception}");
+                //    return false;
+                //}
                 catch (Exception exception)
                 {
                     // 未知的异常，不再继续

--- a/src/dotnetCampus.Ipc/Pipes/IpcClientService.cs
+++ b/src/dotnetCampus.Ipc/Pipes/IpcClientService.cs
@@ -85,7 +85,7 @@ namespace dotnetCampus.Ipc.Pipes
         /// <returns></returns>
         public Task Start(bool shouldRegisterToPeer = true)
         {
-            return StartInternalAsync(isReConnect:false,shouldRegisterToPeer);
+            return StartInternalAsync(isReConnect: false, shouldRegisterToPeer);
         }
 
         /// <inheritdoc cref="Start"/>
@@ -111,7 +111,8 @@ namespace dotnetCampus.Ipc.Pipes
             {
                 // 理论上不应该存在任何异常的才对，但是由于开放给上层业务端定制。如果存在任何业务端的异常，那就应该设置给 _namedPipeClientStreamTaskCompletionSource 里。否则有一些逻辑将会进入等待，如 Write 系列，等待的 _namedPipeClientStreamTaskCompletionSource 的 Task 将永远不会被释放
                 // 包装到 IpcClientPipeConnectionException 里面，方便其他逻辑捕获异常。毕竟要是上层业务端定制的逻辑抛出奇怪类型的异常，那调用 Write 系列的就不好捕获
-                _namedPipeClientStreamTaskCompletionSource.TrySetException(new IpcClientPipeConnectionException(PeerName, e));
+                _namedPipeClientStreamTaskCompletionSource.TrySetException(
+                    new IpcClientPipeConnectionException(PeerName, e));
                 throw;
             }
 

--- a/src/dotnetCampus.Ipc/Pipes/IpcClientService.cs
+++ b/src/dotnetCampus.Ipc/Pipes/IpcClientService.cs
@@ -102,8 +102,7 @@ namespace dotnetCampus.Ipc.Pipes
                 var result = await ConnectNamedPipeAsync(isReConnect, namedPipeClientStream);
                 if (!result)
                 {
-                    _namedPipeClientStreamTaskCompletionSource.TrySetException(
-                        new IpcClientPipeConnectionException(PeerName));
+                    _namedPipeClientStreamTaskCompletionSource.TrySetException(new IpcClientPipeConnectionException(PeerName));
                     return false;
                 }
             }
@@ -132,7 +131,7 @@ namespace dotnetCampus.Ipc.Pipes
         /// </summary>
         /// <param name="isReConnect">是否属于重新连接</param>
         /// <param name="namedPipeClientStream"></param>
-        /// <returns></returns>
+        /// <returns>True 连接成功</returns>
         /// 独立方法，方便 dnspy 调试
         private async Task<bool> ConnectNamedPipeAsync(bool isReConnect, NamedPipeClientStream namedPipeClientStream)
         {

--- a/src/dotnetCampus.Ipc/Pipes/IpcClientService.cs
+++ b/src/dotnetCampus.Ipc/Pipes/IpcClientService.cs
@@ -144,7 +144,7 @@ namespace dotnetCampus.Ipc.Pipes
             }
             else
             {
-               return await CustomConnectNamedPipeAsync(connector, namedPipeClientStream);
+               return await CustomConnectNamedPipeAsync(connector, isReConnect, namedPipeClientStream);
             }
         }
 
@@ -153,12 +153,13 @@ namespace dotnetCampus.Ipc.Pipes
         /// </summary>
         /// <param name="ipcClientPipeConnector"></param>
         /// <param name="namedPipeClientStream"></param>
+        /// <param name="isReConnect">是否属于重新连接</param>
         /// <returns></returns>
-        private async Task<bool> CustomConnectNamedPipeAsync(IIpcClientPipeConnector ipcClientPipeConnector,
+        private async Task<bool> CustomConnectNamedPipeAsync(IIpcClientPipeConnector ipcClientPipeConnector, bool isReConnect,
             NamedPipeClientStream namedPipeClientStream)
         {
             Logger.Trace($"Connecting NamedPipe by {nameof(CustomConnectNamedPipeAsync)}. LocalClient:'{IpcContext.PipeName}';RemoteServer:'{PeerName}'");
-            var ipcClientPipeConnectContext = new IpcClientPipeConnectionContext(PeerName, namedPipeClientStream, CancellationToken.None);
+            var ipcClientPipeConnectContext = new IpcClientPipeConnectionContext(PeerName, namedPipeClientStream, CancellationToken.None, isReConnect);
             var result = await ipcClientPipeConnector.ConnectNamedPipeAsync(ipcClientPipeConnectContext);
             Logger.Trace($"Connected NamedPipe by {nameof(CustomConnectNamedPipeAsync)} Success={result.Success} {result.Reason}. LocalClient:'{IpcContext.PipeName}';RemoteServer:'{PeerName}'");
 

--- a/src/dotnetCampus.Ipc/Pipes/IpcClientService.cs
+++ b/src/dotnetCampus.Ipc/Pipes/IpcClientService.cs
@@ -82,10 +82,16 @@ namespace dotnetCampus.Ipc.Pipes
         /// 启动客户端，启动的时候将会去主动连接服务端，然后向服务端注册自身
         /// </summary>
         /// <param name="shouldRegisterToPeer">是否需要向对方注册</param>
+        /// <exception cref="IpcClientPipeConnectionException">连接失败时抛出</exception>
         /// <returns></returns>
-        public Task Start(bool shouldRegisterToPeer = true)
+        public async Task Start(bool shouldRegisterToPeer = true)
         {
-            return StartInternalAsync(isReConnect: false, shouldRegisterToPeer);
+            var result = await StartInternalAsync(isReConnect: false, shouldRegisterToPeer);
+
+            if (!result)
+            {
+                throw new IpcClientPipeConnectionException(PeerName);
+            }
         }
 
         /// <inheritdoc cref="Start"/>

--- a/src/dotnetCampus.Ipc/Pipes/IpcClientService.cs
+++ b/src/dotnetCampus.Ipc/Pipes/IpcClientService.cs
@@ -159,9 +159,10 @@ namespace dotnetCampus.Ipc.Pipes
         {
             Logger.Trace($"Connecting NamedPipe by {nameof(CustomConnectNamedPipeAsync)}. LocalClient:'{IpcContext.PipeName}';RemoteServer:'{PeerName}'");
             var ipcClientPipeConnectContext = new IpcClientPipeConnectionContext(PeerName, namedPipeClientStream, CancellationToken.None);
-            await ipcClientPipeConnector.ConnectNamedPipeAsync(ipcClientPipeConnectContext);
+            var result = await ipcClientPipeConnector.ConnectNamedPipeAsync(ipcClientPipeConnectContext);
+            Logger.Trace($"Connected NamedPipe by {nameof(CustomConnectNamedPipeAsync)} Success={result.Success} {result.Reason}. LocalClient:'{IpcContext.PipeName}';RemoteServer:'{PeerName}'");
 
-            return true;
+            return result.Success;
         }
 
         /// <summary>

--- a/src/dotnetCampus.Ipc/Pipes/PipeConnectors/IIpcClientPipeConnector.cs
+++ b/src/dotnetCampus.Ipc/Pipes/PipeConnectors/IIpcClientPipeConnector.cs
@@ -12,5 +12,31 @@ public interface IIpcClientPipeConnector
     /// </summary>
     /// <param name="ipcClientPipeConnectionContext"></param>
     /// <returns></returns>
-    Task ConnectNamedPipeAsync(IpcClientPipeConnectionContext ipcClientPipeConnectionContext);
+    Task<IpcClientNamedPipeConnectResult> ConnectNamedPipeAsync(IpcClientPipeConnectionContext ipcClientPipeConnectionContext);
+}
+
+/// <summary>
+/// 客户端的管道连接结果
+/// </summary>
+public readonly struct IpcClientNamedPipeConnectResult
+{
+    /// <summary>
+    /// 创建客户端的管道连接结果
+    /// </summary>
+    /// <param name="success"></param>
+    public IpcClientNamedPipeConnectResult(bool success, string? reason = null)
+    {
+        Success = success;
+        Reason = reason;
+    }
+
+    /// <summary>
+    /// 连接是否成功
+    /// </summary>
+    public bool Success { get; }
+
+    /// <summary>
+    /// 连接成功或失败的原因
+    /// </summary>
+    public string? Reason { get; }
 }

--- a/src/dotnetCampus.Ipc/Pipes/PipeConnectors/IpcClientPipeConnectionContext.cs
+++ b/src/dotnetCampus.Ipc/Pipes/PipeConnectors/IpcClientPipeConnectionContext.cs
@@ -12,11 +12,12 @@ public readonly struct IpcClientPipeConnectionContext
     /// 用于传递客户端的管道连接参数
     /// </summary>
     public IpcClientPipeConnectionContext(string peerName, NamedPipeClientStream namedPipeClientStream,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken, bool isReConnect)
     {
         PeerName = peerName;
         NamedPipeClientStream = namedPipeClientStream;
         CancellationToken = cancellationToken;
+        IsReConnect = isReConnect;
     }
 
     /// <summary>
@@ -33,4 +34,9 @@ public readonly struct IpcClientPipeConnectionContext
     /// 连接取消标记
     /// </summary>
     public CancellationToken CancellationToken { get; }
+
+    /// <summary>
+    /// 是否属于重新连接。如 Peer 断开之后的重新连接
+    /// </summary>
+    public bool IsReConnect { get; }
 }

--- a/src/dotnetCampus.Ipc/Pipes/PipeConnectors/IpcClientPipeConnector.cs
+++ b/src/dotnetCampus.Ipc/Pipes/PipeConnectors/IpcClientPipeConnector.cs
@@ -14,7 +14,7 @@ public class IpcClientPipeConnector : IIpcClientPipeConnector
     /// </summary>
     /// <param name="canContinue">是否能继续连接的判断委托</param>
     /// <param name="stepTimeout">每一次连接的等待超时时间</param>
-    /// <param name="stepSleepTimeGetter">等待超时之后，下一次连接的延迟时间。连接的之间间隔时间</param>
+    /// <param name="stepSleepTimeGetter">等待超时之后，下一次连接的延迟时间。连接的之间间隔时间。可以根据连接次数，不断延长延迟时间</param>
     public IpcClientPipeConnector(CanContinueDelegate canContinue, TimeSpan? stepTimeout = null,
         GetStepSleepTimeDelegate? stepSleepTimeGetter = null)
     {
@@ -34,6 +34,9 @@ public class IpcClientPipeConnector : IIpcClientPipeConnector
             try
             {
                 stepCount++;
+                // 由于 namedPipeClientStream.ConnectAsync 底层也是使用 Task.Run 执行 Connect 的逻辑
+                // 且 ConnectAsync 在 .NET Framework 4.5 不存在
+                // 因此这里就使用 Task.Run 执行
                 await Task.Run(() => namedPipeClientStream.Connect((int) StepTimeout.TotalMilliseconds))
                     .ConfigureAwait(false);
                 return;

--- a/src/dotnetCampus.Ipc/Pipes/PipeConnectors/IpcClientPipeConnector.cs
+++ b/src/dotnetCampus.Ipc/Pipes/PipeConnectors/IpcClientPipeConnector.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Threading.Tasks;
-using dotnetCampus.Ipc.Exceptions;
 
 namespace dotnetCampus.Ipc.Pipes.PipeConnectors;
 
@@ -24,7 +23,7 @@ public class IpcClientPipeConnector : IIpcClientPipeConnector
     }
 
     /// <inheritdoc />
-    public async Task ConnectNamedPipeAsync(IpcClientPipeConnectionContext ipcClientPipeConnectionContext)
+    public async Task<IpcClientNamedPipeConnectResult> ConnectNamedPipeAsync(IpcClientPipeConnectionContext ipcClientPipeConnectionContext)
     {
         var namedPipeClientStream = ipcClientPipeConnectionContext.NamedPipeClientStream;
 
@@ -39,7 +38,7 @@ public class IpcClientPipeConnector : IIpcClientPipeConnector
                 // 因此这里就使用 Task.Run 执行
                 await Task.Run(() => namedPipeClientStream.Connect((int) StepTimeout.TotalMilliseconds))
                     .ConfigureAwait(false);
-                return;
+                return new IpcClientNamedPipeConnectResult(true);
             }
             catch (TimeoutException)
             {
@@ -56,7 +55,7 @@ public class IpcClientPipeConnector : IIpcClientPipeConnector
             }
             else
             {
-                throw new IpcClientPipeConnectionException(ipcClientPipeConnectionContext.PeerName);
+                return new IpcClientNamedPipeConnectResult(false, "CanContinue return false");
             }
         }
     }

--- a/src/dotnetCampus.Ipc/Pipes/PipeConnectors/IpcClientPipeConnector.cs
+++ b/src/dotnetCampus.Ipc/Pipes/PipeConnectors/IpcClientPipeConnector.cs
@@ -12,9 +12,9 @@ public class IpcClientPipeConnector : IIpcClientPipeConnector
     /// <summary>
     /// 创建默认的配置客户端连接方法
     /// </summary>
-    /// <param name="canContinue"></param>
-    /// <param name="stepTimeout"></param>
-    /// <param name="stepSleepTimeGetter"></param>
+    /// <param name="canContinue">是否能继续连接的判断委托</param>
+    /// <param name="stepTimeout">每一次连接的等待超时时间</param>
+    /// <param name="stepSleepTimeGetter">等待超时之后，下一次连接的延迟时间。连接的之间间隔时间</param>
     public IpcClientPipeConnector(CanContinueDelegate canContinue, TimeSpan? stepTimeout = null,
         GetStepSleepTimeDelegate? stepSleepTimeGetter = null)
     {

--- a/src/dotnetCampus.Ipc/Threading/IIpcThreadPool.cs
+++ b/src/dotnetCampus.Ipc/Threading/IIpcThreadPool.cs
@@ -24,4 +24,14 @@ namespace dotnetCampus.Ipc.Threading
         /// </remarks>
         Task<Task> Run(Action action, ILogger? logger);
     }
+
+    public abstract class CustomIpcThreadPoolBase : IIpcThreadPool
+    {
+        Task<Task> IIpcThreadPool.Run(Action action, ILogger? logger)
+        {
+            return Run(action);
+        }
+
+        protected abstract Task<Task> Run(Action action);
+    }
 }

--- a/src/dotnetCampus.Ipc/Threading/IIpcThreadPool.cs
+++ b/src/dotnetCampus.Ipc/Threading/IIpcThreadPool.cs
@@ -25,6 +25,9 @@ namespace dotnetCampus.Ipc.Threading
         Task<Task> Run(Action action, ILogger? logger);
     }
 
+    /// <summary>
+    /// 自定义的 IPC 所采用的线程池
+    /// </summary>
     public abstract class CustomIpcThreadPoolBase : IIpcThreadPool
     {
         Task<Task> IIpcThreadPool.Run(Action action, ILogger? logger)
@@ -32,6 +35,7 @@ namespace dotnetCampus.Ipc.Threading
             return Run(action);
         }
 
+        /// <inheritdoc cref="IIpcThreadPool.Run"/>
         protected abstract Task<Task> Run(Action action);
     }
 }

--- a/tests/dotnetCampus.Ipc.Tests/PeerReConnectorTest.cs
+++ b/tests/dotnetCampus.Ipc.Tests/PeerReConnectorTest.cs
@@ -27,8 +27,8 @@ namespace dotnetCampus.Ipc.Tests
                 // 让 c 主动连接 a 然后聊聊天
                 // 预期可以让 a 获取到 c 的连接事件
 
-                var aName = "A_PeerConnectorTest_01";
-                var bName = "B_PeerConnectorTest_01";
+                var aName = "A_PeerConnectorTest_02";
+                var bName = "B_PeerConnectorTest_02";
                 var aResponse = new byte[] { 0xF1, 0xF3 };
                 var bRequest = new byte[] { 0xF1, 0xF2, 0xF3 };
                 var cRequest = new byte[] { 0x01, 0x05, 0xF3 };

--- a/tests/dotnetCampus.Ipc.Tests/PeerReConnectorTest.cs
+++ b/tests/dotnetCampus.Ipc.Tests/PeerReConnectorTest.cs
@@ -1,14 +1,13 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
-using Castle.DynamicProxy.Generators.Emitters.SimpleAST;
 using dotnetCampus.Ipc.Context;
 using dotnetCampus.Ipc.Internals;
 using dotnetCampus.Ipc.Messages;
 using dotnetCampus.Ipc.Pipes;
-using dotnetCampus.Ipc.Utils.Extensions;
+using dotnetCampus.Ipc.Pipes.PipeConnectors;
+using dotnetCampus.Ipc.Threading;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using MSTest.Extensions.Contracts;
 
 namespace dotnetCampus.Ipc.Tests
@@ -16,6 +15,221 @@ namespace dotnetCampus.Ipc.Tests
     [TestClass]
     public class PeerReConnectorTest
     {
+        [ContractTestCase]
+        public void IpcClientPipeConnectorTest()
+        {
+            "设置自动重新连接，但是重新连接器里面永远返回不继续连接。在对方结束之后，重新再开始，可以被重复连接".Test(async () =>
+            {
+                // 先启动 a 和 b 两个
+                // 让 b 主动连接 a 然后聊聊天
+                // 接着将 b 结束，此时 a 的 peer 将会断开连接
+                // 然后启动 c 让 c 用原本 b 的 name 从而假装是 b 重新再开始
+                // 让 c 主动连接 a 然后聊聊天
+                // 预期可以让 a 获取到 c 的连接事件
+
+                var aName = "A_PeerConnectorTest_01";
+                var bName = "B_PeerConnectorTest_01";
+                var aResponse = new byte[] { 0xF1, 0xF3 };
+                var bRequest = new byte[] { 0xF1, 0xF2, 0xF3 };
+                var cRequest = new byte[] { 0x01, 0x05, 0xF3 };
+
+                var a = new IpcProvider(aName, new IpcConfiguration()
+                {
+                    AutoReconnectPeers = true, // 设置自动重新连接
+                    // 但是重新连接器里面永远返回不继续连接
+                    IpcClientPipeConnector =
+                        new IpcClientPipeConnector(context => false,
+                            // 设置每一步都是快速超时
+                            stepTimeout: TimeSpan.FromMilliseconds(100)),
+
+                    DefaultIpcRequestHandler = new DelegateIpcRequestHandler(context =>
+                    new IpcHandleRequestMessageResult(new IpcMessage("B回复", aResponse))),
+                    IpcTaskScheduling = IpcTaskScheduling.LocalOneByOne,
+                });
+
+                var connectCount = 0;
+                var peerBrokenTask = new TaskCompletionSource<bool>();
+                a.PeerConnected += (sender, args) =>
+                {
+                    connectCount++;
+
+                    args.Peer.PeerConnectionBroken += (o, brokenArgs) =>
+                    {
+                        peerBrokenTask.TrySetResult(true);
+                    };
+                };
+
+                var b = new IpcProvider(bName, new IpcConfiguration()
+                {
+                    AutoReconnectPeers = true, // 设置自动重新连接
+                    // 但是重新连接器里面永远返回不继续连接
+                    IpcClientPipeConnector = new IpcClientPipeConnector(context => false),
+
+                    IpcTaskScheduling = IpcTaskScheduling.LocalOneByOne,
+                });
+
+                a.StartServer();
+                b.StartServer();
+
+                // 让 b 主动连接 a 然后聊聊天
+                var peer1 = await b.GetOrCreatePeerProxyAsync(aName);
+                var request1 = await peer1.GetResponseAsync(new IpcMessage("Test", bRequest));
+                Assert.AreEqual(true, aResponse.AsSpan().SequenceEqual(request1.Body.AsSpan()));
+                await Task.Yield();
+
+                // 能收到一次连接。这是预期的
+                Assert.AreEqual(1, connectCount);
+
+                var peerReconnectedCount = 0;
+                peer1.PeerReconnected += (sender, args) =>
+                {
+                    peerReconnectedCount++;
+                };
+
+                // 将 b 结束，此时 a 的 peer 将会断开连接
+                b.Dispose();
+
+                // 预期 b 结束时，能收到 PeerConnectionBroken 事件
+                await Task.WhenAny(peerBrokenTask.Task, Task.Delay(TimeSpan.FromSeconds(2)));
+                if (!peerBrokenTask.Task.IsCompleted)
+                {
+#if DEBUG
+                    // 进入断点，也许上面的时间太短
+                    await Task.WhenAny(peerBrokenTask.Task, Task.Delay(TimeSpan.FromMinutes(5)));
+#endif
+                }
+                // 判断是否能收到对方断开的消息
+                Assert.AreEqual(true, peerBrokenTask.Task.IsCompleted);
+                Assert.AreEqual(true, peerBrokenTask.Task.Result);
+
+                // 等待重新连接失败
+                await Task.Delay(TimeSpan.FromSeconds(5));
+
+                // 确定 b 断开，再启动 c 去主动连接
+                var c = new IpcProvider(bName, new IpcConfiguration()
+                {
+                    AutoReconnectPeers = true, // 设置自动重新连接
+                    // 但是重新连接器里面永远返回不继续连接
+                    IpcClientPipeConnector = new IpcClientPipeConnector(context => false),
+
+                    IpcTaskScheduling = IpcTaskScheduling.LocalOneByOne,
+                });
+                c.StartServer();
+
+                // 启动 c 去主动连接
+                var peer2 = await c.GetOrCreatePeerProxyAsync(aName);
+                // 发送一条请求获取响应，可以证明连接到符合预期的。同时也等待对方完成连接
+                var request2 = await peer2.GetResponseAsync(new IpcMessage("Test", cRequest));
+                Assert.AreEqual(true, aResponse.AsSpan().SequenceEqual(request2.Body.AsSpan()));
+
+                // 可以被重复连接
+                // 也就是会被连接两次
+                // 不存在被重复连接
+                Assert.AreEqual(2, connectCount);
+                Assert.AreEqual(0, peerReconnectedCount);
+            });
+        }
+
+        [ContractTestCase]
+        public void Connect()
+        {
+            "不自动重新连接，对方结束之后，重新再开始，可以被重复连接".Test(async () =>
+            {
+                // 先启动 a 和 b 两个
+                // 让 b 主动连接 a 然后聊聊天
+                // 接着将 b 结束，此时 a 的 peer 将会断开连接
+                // 然后启动 c 让 c 用原本 b 的 name 从而假装是 b 重新再开始
+                // 让 c 主动连接 a 然后聊聊天
+                // 预期可以让 a 获取到 c 的连接事件
+
+                var aName = "A_PeerConnectorTest_01";
+                var bName = "B_PeerConnectorTest_01";
+                var aResponse = new byte[] { 0xF1, 0xF3 };
+                var bRequest = new byte[] { 0xF1, 0xF2, 0xF3 };
+                var cRequest = new byte[] { 0x01, 0x05, 0xF3 };
+
+                var a = new IpcProvider(aName, new IpcConfiguration()
+                {
+                    AutoReconnectPeers = false, // 不自动重新连接
+                    DefaultIpcRequestHandler = new DelegateIpcRequestHandler(context =>
+                    new IpcHandleRequestMessageResult(new IpcMessage("B回复", aResponse))),
+                    IpcTaskScheduling = IpcTaskScheduling.LocalOneByOne,
+                });
+
+                var connectCount = 0;
+                var peerBrokenTask = new TaskCompletionSource<bool>();
+                a.PeerConnected += (sender, args) =>
+                {
+                    connectCount++;
+
+                    args.Peer.PeerConnectionBroken += (o, brokenArgs) =>
+                    {
+                        peerBrokenTask.TrySetResult(true);
+                    };
+                };
+
+                var b = new IpcProvider(bName, new IpcConfiguration()
+                {
+                    AutoReconnectPeers = false, // 不自动重新连接
+                    IpcTaskScheduling = IpcTaskScheduling.LocalOneByOne,
+                });
+
+                a.StartServer();
+                b.StartServer();
+
+                // 让 b 主动连接 a 然后聊聊天
+                var peer1 = await b.GetOrCreatePeerProxyAsync(aName);
+                var request1 = await peer1.GetResponseAsync(new IpcMessage("Test", bRequest));
+                Assert.AreEqual(true, aResponse.AsSpan().SequenceEqual(request1.Body.AsSpan()));
+                await Task.Yield();
+
+                // 能收到一次连接。这是预期的
+                Assert.AreEqual(1, connectCount);
+
+                var peerReconnectedCount = 0;
+                peer1.PeerReconnected += (sender, args) =>
+                {
+                    peerReconnectedCount++;
+                };
+
+                // 将 b 结束，此时 a 的 peer 将会断开连接
+                b.Dispose();
+
+                // 预期 b 结束时，能收到 PeerConnectionBroken 事件
+                await Task.WhenAny(peerBrokenTask.Task, Task.Delay(TimeSpan.FromSeconds(2)));
+                if (!peerBrokenTask.Task.IsCompleted)
+                {
+#if DEBUG
+                    // 进入断点，也许上面的时间太短
+                    await Task.WhenAny(peerBrokenTask.Task, Task.Delay(TimeSpan.FromMinutes(5)));
+#endif
+                }
+                // 判断是否能收到对方断开的消息
+                Assert.AreEqual(true, peerBrokenTask.Task.IsCompleted);
+                Assert.AreEqual(true, peerBrokenTask.Task.Result);
+
+                // 确定 b 断开，再启动 c 去主动连接
+                var c = new IpcProvider(bName, new IpcConfiguration()
+                {
+                    AutoReconnectPeers = false, // 不自动重新连接
+                    IpcTaskScheduling = IpcTaskScheduling.LocalOneByOne,
+                });
+                c.StartServer();
+
+                // 启动 c 去主动连接
+                var peer2 = await c.GetOrCreatePeerProxyAsync(aName);
+                // 发送一条请求获取响应，可以证明连接到符合预期的。同时也等待对方完成连接
+                var request2 = await peer2.GetResponseAsync(new IpcMessage("Test", cRequest));
+                Assert.AreEqual(true, aResponse.AsSpan().SequenceEqual(request2.Body.AsSpan()));
+
+                // 可以被重复连接
+                // 也就是会被连接两次
+                // 不存在被重复连接
+                Assert.AreEqual(2, connectCount);
+                Assert.AreEqual(0, peerReconnectedCount);
+            });
+        }
+
         [ContractTestCase]
         public void Reconnect()
         {
@@ -96,6 +310,4 @@ namespace dotnetCampus.Ipc.Tests
             });
         }
     }
-
-
 }


### PR DESCRIPTION
- 原本的线程模型，在 IPC 足够断续，将会存在大量的线程启动和退出。导致 IPC 消息由于等待线程启动而存在较大延迟。支持业务端特殊需求，传入自定义的线程池方法
- 自动重连加上防止自动无限重试机制，当进入防止自动无限重试机制时，即使后续被主动连接，也会失败。原先是抛出异常，让其他逻辑没有执行，现在修改为通过返回值，如此可以处理连接失败
- 修复连接失败时，没有设置 `_namedPipeClientStreamTaskCompletionSource` 状态，导致写入等方法在进行等待