### PR TITLE
为 IPC 代理和对接增加 Id

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -16,7 +16,7 @@ jobs:
         dotnet-version: |
           3.1.x
           5.0.x
-          6.0.100
+          6.0.x
 
     - name: Build
       run: dotnet build --configuration Release

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -10,14 +10,6 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: |
-          3.1.x
-          5.0.x
-          6.0.x
-
     - name: Build
       run: dotnet build --configuration Release
 

--- a/.github/workflows/nuget-tag-publish.yml
+++ b/.github/workflows/nuget-tag-publish.yml
@@ -19,7 +19,7 @@ jobs:
         dotnet-version: |
           3.1.x
           5.0.x
-          6.0.100
+          6.0.x
 
     - name: Install dotnet tool
       run: dotnet tool install -g dotnetCampus.TagToVersion

--- a/dotnetCampus.Ipc.sln
+++ b/dotnetCampus.Ipc.sln
@@ -26,12 +26,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnetCampus.Ipc.PipeMvcCli
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "dotnetCampus.Ipc.PipeMvcShare", "src\PipeMvc\dotnetCampus.Ipc.PipeMvcShare\dotnetCampus.Ipc.PipeMvcShare.shproj", "{05ACE3BB-61E5-4592-AC73-747850DB1081}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{11767A0B-CBFB-4323-BCEE-DE1CDD6C4B4B}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{11767A0B-CBFB-4323-BCEE-DE1CDD6C4B4B}"
 	ProjectSection(SolutionItems) = preProject
 		Directory.Build.props = Directory.Build.props
-		.github\workflows\dotnet-core.yml = .github\workflows\dotnet-core.yml
-		.github\workflows\dotnet-format.yml = .github\workflows\dotnet-format.yml
-		.github\workflows\nuget-tag-publish.yml = .github\workflows\nuget-tag-publish.yml
 		build\Version.props = build\Version.props
 	EndProjectSection
 EndProject
@@ -49,16 +46,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PipeMvcServerDemo", "demo\P
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "IpcRemotingObjectDemo", "IpcRemotingObjectDemo", "{927CE552-9207-47AD-9595-650C5A0624A9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IpcRemotingObjectServerDemo", "demo\IpcRemotingObjectDemo\IpcRemotingObjectServerDemo\IpcRemotingObjectServerDemo.csproj", "{CB343EAE-9DA2-49F3-B39B-E9CDDCEB2292}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IpcRemotingObjectServerDemo", "demo\IpcRemotingObjectDemo\IpcRemotingObjectServerDemo\IpcRemotingObjectServerDemo.csproj", "{CB343EAE-9DA2-49F3-B39B-E9CDDCEB2292}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IpcRemotingObjectClientDemo", "demo\IpcRemotingObjectDemo\IpcRemotingObjectClientDemo\IpcRemotingObjectClientDemo.csproj", "{6639929E-3AC1-47D9-BE74-97FDF3C29B6B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IpcRemotingObjectClientDemo", "demo\IpcRemotingObjectDemo\IpcRemotingObjectClientDemo\IpcRemotingObjectClientDemo.csproj", "{6639929E-3AC1-47D9-BE74-97FDF3C29B6B}"
 EndProject
 Global
-	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		src\PipeMvc\dotnetCampus.Ipc.PipeMvcShare\dotnetCampus.Ipc.PipeMvcShare.projitems*{05ace3bb-61e5-4592-ac73-747850db1081}*SharedItemsImports = 13
-		src\PipeMvc\dotnetCampus.Ipc.PipeMvcShare\dotnetCampus.Ipc.PipeMvcShare.projitems*{0f6b9c0c-7a64-4b21-bc28-e52565245a1a}*SharedItemsImports = 5
-		src\PipeMvc\dotnetCampus.Ipc.PipeMvcShare\dotnetCampus.Ipc.PipeMvcShare.projitems*{1ace3261-cc3d-4442-8c83-516721b3da46}*SharedItemsImports = 5
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Debug|x64 = Debug|x64
@@ -233,5 +225,10 @@ Global
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C8828641-2F8C-4B6A-BF1D-F8F3C8C8454D}
+	EndGlobalSection
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		src\PipeMvc\dotnetCampus.Ipc.PipeMvcShare\dotnetCampus.Ipc.PipeMvcShare.projitems*{05ace3bb-61e5-4592-ac73-747850db1081}*SharedItemsImports = 13
+		src\PipeMvc\dotnetCampus.Ipc.PipeMvcShare\dotnetCampus.Ipc.PipeMvcShare.projitems*{0f6b9c0c-7a64-4b21-bc28-e52565245a1a}*SharedItemsImports = 5
+		src\PipeMvc\dotnetCampus.Ipc.PipeMvcShare\dotnetCampus.Ipc.PipeMvcShare.projitems*{1ace3261-cc3d-4442-8c83-516721b3da46}*SharedItemsImports = 5
 	EndGlobalSection
 EndGlobal

--- a/src/dotnetCampus.Ipc.Analyzers/SourceGenerators/Compiling/Members/IpcPublicMethodInfo.cs
+++ b/src/dotnetCampus.Ipc.Analyzers/SourceGenerators/Compiling/Members/IpcPublicMethodInfo.cs
@@ -84,7 +84,7 @@ internal class IpcPublicMethodInfo : IPublicIpcObjectProxyMemberGenerator, IPubl
 
 Task {methodContainingTypeName}.{_contractMethod.Name}({parameters})
 {{
-    return CallMethodAsync(""{methodId}"", new Garm<object?>[] {{ {arguments} }}, {namedValues});
+    return CallMethodAsync({methodId}, new Garm<object?>[] {{ {arguments} }}, {namedValues});
 }}
 
                 ",
@@ -93,7 +93,7 @@ Task {methodContainingTypeName}.{_contractMethod.Name}({parameters})
 
 Task<{returnTypeName}> {methodContainingTypeName}.{_contractMethod.Name}({parameters})
 {{
-    return CallMethodAsync<{returnTypeName}>(""{methodId}"", new Garm<object?>[] {{ {arguments} }}, {namedValues});
+    return CallMethodAsync<{returnTypeName}>({methodId}, new Garm<object?>[] {{ {arguments} }}, {namedValues});
 }}
 
                 ",
@@ -102,19 +102,19 @@ Task<{returnTypeName}> {methodContainingTypeName}.{_contractMethod.Name}({parame
                     ? @$"
 void {methodContainingTypeName}.{_contractMethod.Name}({parameters})
 {{
-    CallMethod(""{methodId}"", new Garm<object?>[] {{ {arguments} }}, {namedValues}).Wait();
+    CallMethod({methodId}, new Garm<object?>[] {{ {arguments} }}, {namedValues}).Wait();
 }}"
                     : @$"
 void {methodContainingTypeName}.{_contractMethod.Name}({parameters})
 {{
-    _ = CallMethod(""{methodId}"", new Garm<object?>[] {{ {arguments} }}, {namedValues});
+    _ = CallMethod({methodId}, new Garm<object?>[] {{ {arguments} }}, {namedValues});
 }}",
 
                 // 同步 T 方法。
                 (false, _) => $@"
 {returnTypeName} {methodContainingTypeName}.{_contractMethod.Name}({parameters})
 {{
-    return CallMethod<{returnTypeName}>(""{methodId}"", new Garm<object?>[] {{ {arguments} }}, {namedValues}).Result;
+    return CallMethod<{returnTypeName}>({methodId}, new Garm<object?>[] {{ {arguments} }}, {namedValues}).Result;
 }}
                 ",
             }
@@ -150,7 +150,7 @@ void {methodContainingTypeName}.{_contractMethod.Name}({parameters})
     /// <returns>方法源代码。</returns>
     public string GenerateJointMatch(SourceTextBuilder builder, string real)
     {
-        var memberId = MemberIdGenerator.GenerateMethodId(_contractMethod);
+        var methodId = MemberIdGenerator.GenerateMethodId(_contractMethod);
         var containingTypeName = builder.SimplifyNameByAddUsing(_contractMethod.ContainingType);
         var parameterTypes = GenerateMethodParameterTypes(builder, _contractMethod.Parameters);
         var arguments = GenerateMethodArguments(_contractMethod.Parameters);
@@ -164,8 +164,8 @@ void {methodContainingTypeName}.{_contractMethod.Name}({parameters})
             // 异步 Task 方法。
             var call = $"{real}.{_contractMethod.Name}({arguments})";
             var sourceCode = string.IsNullOrWhiteSpace(arguments)
-                ? $"MatchMethod(\"{memberId}\", new Func<Task>(() => {call}));"
-                : $"MatchMethod(\"{memberId}\", new Func<{parameterTypes}, Task>(({arguments}) => {call}));";
+                ? $"MatchMethod({methodId}, new Func<Task>(() => {call}));"
+                : $"MatchMethod({methodId}, new Func<{parameterTypes}, Task>(({arguments}) => {call}));";
             return sourceCode;
         }
         else if (isAsync && !returnsVoid)
@@ -174,8 +174,8 @@ void {methodContainingTypeName}.{_contractMethod.Name}({parameters})
             var @return = $"Task<Garm<{returnTypeName}>>";
             var call = GenerateGarmReturn(builder, asyncReturnType!, $"await {real}.{_contractMethod.Name}({arguments}).ConfigureAwait(false)");
             var sourceCode = string.IsNullOrWhiteSpace(arguments)
-                ? $"MatchMethod(\"{memberId}\", new Func<{@return}>(async () => {call}));"
-                : $"MatchMethod(\"{memberId}\", new Func<{parameterTypes}, {@return}>(async ({arguments}) => {call}));";
+                ? $"MatchMethod({methodId}, new Func<{@return}>(async () => {call}));"
+                : $"MatchMethod({methodId}, new Func<{parameterTypes}, {@return}>(async ({arguments}) => {call}));";
             return sourceCode;
         }
         else if (!isAsync && returnsVoid)
@@ -183,8 +183,8 @@ void {methodContainingTypeName}.{_contractMethod.Name}({parameters})
             // 同步 void 方法。
             var call = $"{real}.{_contractMethod.Name}({arguments})";
             var sourceCode = string.IsNullOrWhiteSpace(arguments)
-                ? $"MatchMethod(\"{memberId}\", new Action(() => {call}));"
-                : $"MatchMethod(\"{memberId}\", new Action<{parameterTypes}>(({arguments}) => {call}));";
+                ? $"MatchMethod({methodId}, new Action(() => {call}));"
+                : $"MatchMethod({methodId}, new Action<{parameterTypes}>(({arguments}) => {call}));";
             return sourceCode;
         }
         else
@@ -193,8 +193,8 @@ void {methodContainingTypeName}.{_contractMethod.Name}({parameters})
             var @return = $"Garm<{returnTypeName}>";
             var call = GenerateGarmReturn(builder, _contractMethod.ReturnType, $"{real}.{_contractMethod.Name}({arguments})");
             var sourceCode = string.IsNullOrWhiteSpace(arguments)
-                ? $"MatchMethod(\"{memberId}\", new Func<{@return}>(() => {call}));"
-                : $"MatchMethod(\"{memberId}\", new Func<{parameterTypes}, {@return}>(({arguments}) => {call}));";
+                ? $"MatchMethod({methodId}, new Func<{@return}>(() => {call}));"
+                : $"MatchMethod({methodId}, new Func<{parameterTypes}, {@return}>(({arguments}) => {call}));";
             return sourceCode;
         }
     }

--- a/src/dotnetCampus.Ipc.Analyzers/SourceGenerators/Compiling/Members/IpcPublicMethodInfo.cs
+++ b/src/dotnetCampus.Ipc.Analyzers/SourceGenerators/Compiling/Members/IpcPublicMethodInfo.cs
@@ -65,6 +65,7 @@ internal class IpcPublicMethodInfo : IPublicIpcObjectProxyMemberGenerator, IPubl
     /// <returns>方法源代码。</returns>
     public MemberDeclarationSourceTextBuilder GenerateProxyMember(SourceTextBuilder builder)
     {
+        var methodId = MemberIdGenerator.GenerateMethodId(_contractMethod);
         var parameters = GenerateMethodParameters(builder, _contractMethod.Parameters);
         var arguments = GenerateGarmArguments(builder, _contractMethod.Parameters);
         var asyncReturnType = GetAsyncReturnType(_contractMethod.ReturnType);
@@ -83,7 +84,7 @@ internal class IpcPublicMethodInfo : IPublicIpcObjectProxyMemberGenerator, IPubl
 
 Task {methodContainingTypeName}.{_contractMethod.Name}({parameters})
 {{
-    return CallMethodAsync(new Garm<object?>[] {{ {arguments} }}, {namedValues});
+    return CallMethodAsync(""{methodId}"", new Garm<object?>[] {{ {arguments} }}, {namedValues});
 }}
 
                 ",
@@ -92,7 +93,7 @@ Task {methodContainingTypeName}.{_contractMethod.Name}({parameters})
 
 Task<{returnTypeName}> {methodContainingTypeName}.{_contractMethod.Name}({parameters})
 {{
-    return CallMethodAsync<{returnTypeName}>(new Garm<object?>[] {{ {arguments} }}, {namedValues});
+    return CallMethodAsync<{returnTypeName}>(""{methodId}"", new Garm<object?>[] {{ {arguments} }}, {namedValues});
 }}
 
                 ",
@@ -101,19 +102,19 @@ Task<{returnTypeName}> {methodContainingTypeName}.{_contractMethod.Name}({parame
                     ? @$"
 void {methodContainingTypeName}.{_contractMethod.Name}({parameters})
 {{
-    CallMethod(new Garm<object?>[] {{ {arguments} }}, {namedValues}).Wait();
+    CallMethod(""{methodId}"", new Garm<object?>[] {{ {arguments} }}, {namedValues}).Wait();
 }}"
                     : @$"
 void {methodContainingTypeName}.{_contractMethod.Name}({parameters})
 {{
-    _ = CallMethod(new Garm<object?>[] {{ {arguments} }}, {namedValues});
+    _ = CallMethod(""{methodId}"", new Garm<object?>[] {{ {arguments} }}, {namedValues});
 }}",
 
                 // 同步 T 方法。
                 (false, _) => $@"
 {returnTypeName} {methodContainingTypeName}.{_contractMethod.Name}({parameters})
 {{
-    return CallMethod<{returnTypeName}>(new Garm<object?>[] {{ {arguments} }}, {namedValues}).Result;
+    return CallMethod<{returnTypeName}>(""{methodId}"", new Garm<object?>[] {{ {arguments} }}, {namedValues}).Result;
 }}
                 ",
             }
@@ -149,6 +150,7 @@ void {methodContainingTypeName}.{_contractMethod.Name}({parameters})
     /// <returns>方法源代码。</returns>
     public string GenerateJointMatch(SourceTextBuilder builder, string real)
     {
+        var memberId = MemberIdGenerator.GenerateMethodId(_contractMethod);
         var containingTypeName = builder.SimplifyNameByAddUsing(_contractMethod.ContainingType);
         var parameterTypes = GenerateMethodParameterTypes(builder, _contractMethod.Parameters);
         var arguments = GenerateMethodArguments(_contractMethod.Parameters);
@@ -162,8 +164,8 @@ void {methodContainingTypeName}.{_contractMethod.Name}({parameters})
             // 异步 Task 方法。
             var call = $"{real}.{_contractMethod.Name}({arguments})";
             var sourceCode = string.IsNullOrWhiteSpace(arguments)
-                ? $"MatchMethod(nameof({containingTypeName}.{_contractMethod.Name}), new Func<Task>(() => {call}));"
-                : $"MatchMethod(nameof({containingTypeName}.{_contractMethod.Name}), new Func<{parameterTypes}, Task>(({arguments}) => {call}));";
+                ? $"MatchMethod(\"{memberId}\", new Func<Task>(() => {call}));"
+                : $"MatchMethod(\"{memberId}\", new Func<{parameterTypes}, Task>(({arguments}) => {call}));";
             return sourceCode;
         }
         else if (isAsync && !returnsVoid)
@@ -172,8 +174,8 @@ void {methodContainingTypeName}.{_contractMethod.Name}({parameters})
             var @return = $"Task<Garm<{returnTypeName}>>";
             var call = GenerateGarmReturn(builder, asyncReturnType!, $"await {real}.{_contractMethod.Name}({arguments}).ConfigureAwait(false)");
             var sourceCode = string.IsNullOrWhiteSpace(arguments)
-                ? $"MatchMethod(nameof({containingTypeName}.{_contractMethod.Name}), new Func<{@return}>(async () => {call}));"
-                : $"MatchMethod(nameof({containingTypeName}.{_contractMethod.Name}), new Func<{parameterTypes}, {@return}>(async ({arguments}) => {call}));";
+                ? $"MatchMethod(\"{memberId}\", new Func<{@return}>(async () => {call}));"
+                : $"MatchMethod(\"{memberId}\", new Func<{parameterTypes}, {@return}>(async ({arguments}) => {call}));";
             return sourceCode;
         }
         else if (!isAsync && returnsVoid)
@@ -181,8 +183,8 @@ void {methodContainingTypeName}.{_contractMethod.Name}({parameters})
             // 同步 void 方法。
             var call = $"{real}.{_contractMethod.Name}({arguments})";
             var sourceCode = string.IsNullOrWhiteSpace(arguments)
-                ? $"MatchMethod(nameof({containingTypeName}.{_contractMethod.Name}), new Action(() => {call}));"
-                : $"MatchMethod(nameof({containingTypeName}.{_contractMethod.Name}), new Action<{parameterTypes}>(({arguments}) => {call}));";
+                ? $"MatchMethod(\"{memberId}\", new Action(() => {call}));"
+                : $"MatchMethod(\"{memberId}\", new Action<{parameterTypes}>(({arguments}) => {call}));";
             return sourceCode;
         }
         else
@@ -191,8 +193,8 @@ void {methodContainingTypeName}.{_contractMethod.Name}({parameters})
             var @return = $"Garm<{returnTypeName}>";
             var call = GenerateGarmReturn(builder, _contractMethod.ReturnType, $"{real}.{_contractMethod.Name}({arguments})");
             var sourceCode = string.IsNullOrWhiteSpace(arguments)
-                ? $"MatchMethod(nameof({containingTypeName}.{_contractMethod.Name}), new Func<{@return}>(() => {call}));"
-                : $"MatchMethod(nameof({containingTypeName}.{_contractMethod.Name}), new Func<{parameterTypes}, {@return}>(({arguments}) => {call}));";
+                ? $"MatchMethod(\"{memberId}\", new Func<{@return}>(() => {call}));"
+                : $"MatchMethod(\"{memberId}\", new Func<{parameterTypes}, {@return}>(({arguments}) => {call}));";
             return sourceCode;
         }
     }

--- a/src/dotnetCampus.Ipc.Analyzers/SourceGenerators/Compiling/Members/IpcPublicPropertyInfo.cs
+++ b/src/dotnetCampus.Ipc.Analyzers/SourceGenerators/Compiling/Members/IpcPublicPropertyInfo.cs
@@ -74,15 +74,15 @@ internal class IpcPublicPropertyInfo : IPublicIpcObjectProxyMemberGenerator, IPu
 
 {propertyTypeName} {containingTypeName}.{_contractProperty.Name}
 {{
-    get => GetValueAsync<{propertyTypeName}>(""{getMemberId}"", {namedValues}).Result;
-    set => SetValueAsync<{propertyTypeName}>(""{setMemberId}"", {valueArgumentName}, {namedValues}).Wait();
+    get => GetValueAsync<{propertyTypeName}>({getMemberId}, {namedValues}).Result;
+    set => SetValueAsync<{propertyTypeName}>({setMemberId}, {valueArgumentName}, {namedValues}).Wait();
 }}
 
                 ",
                 // get 属性。
                 (true, false) => $@"
 
-{propertyTypeName} {containingTypeName}.{_contractProperty.Name} => GetValueAsync<{propertyTypeName}>(""{getMemberId}"", {namedValues}).Result;
+{propertyTypeName} {containingTypeName}.{_contractProperty.Name} => GetValueAsync<{propertyTypeName}>({getMemberId}, {namedValues}).Result;
 
                 ",
                 // 不支持 set 属性。
@@ -142,12 +142,12 @@ internal class IpcPublicPropertyInfo : IPublicIpcObjectProxyMemberGenerator, IPu
         var (hasGet, hasSet) = (_contractProperty.GetMethod is not null, _contractProperty.SetMethod is not null);
         if (hasGet && hasSet)
         {
-            var sourceCode = $"MatchProperty(\"{getMemberId}\", \"{setMemberId}\", new Func<{garmPropertyTypeName}>(() => {garmPropertyArgumentName}), new Action<{propertyTypeName}>(value => {real}.{_contractProperty.Name} = value));";
+            var sourceCode = $"MatchProperty({getMemberId}, {setMemberId}, new Func<{garmPropertyTypeName}>(() => {garmPropertyArgumentName}), new Action<{propertyTypeName}>(value => {real}.{_contractProperty.Name} = value));";
             return sourceCode;
         }
         else if (hasGet)
         {
-            var sourceCode = $"MatchProperty(\"{getMemberId}\", new Func<{garmPropertyTypeName}>(() => {garmPropertyArgumentName}));";
+            var sourceCode = $"MatchProperty({getMemberId}, new Func<{garmPropertyTypeName}>(() => {garmPropertyArgumentName}));";
             return sourceCode;
         }
         else

--- a/src/dotnetCampus.Ipc.Analyzers/SourceGenerators/Compiling/Members/MemberIdGenerator.cs
+++ b/src/dotnetCampus.Ipc.Analyzers/SourceGenerators/Compiling/Members/MemberIdGenerator.cs
@@ -19,9 +19,6 @@ public static class MemberIdGenerator
         var inputBytes = Encoding.UTF8.GetBytes(text);
         var hashBytes = sha256.ComputeHash(inputBytes);
 
-        return BitConverter.ToString(hashBytes)
-            .Replace("-", "")
-            .Substring(0, 16)
-            .ToLower(CultureInfo.InvariantCulture);
+        return $"0x{BitConverter.ToInt64(hashBytes, 0).ToString("X")}";
     }
 }

--- a/src/dotnetCampus.Ipc.Analyzers/SourceGenerators/Compiling/Members/MemberIdGenerator.cs
+++ b/src/dotnetCampus.Ipc.Analyzers/SourceGenerators/Compiling/Members/MemberIdGenerator.cs
@@ -1,0 +1,27 @@
+﻿using System.Security.Cryptography;
+
+namespace dotnetCampus.Ipc.SourceGenerators.Compiling.Members;
+public static class MemberIdGenerator
+{
+    public static string GeneratePropertyId(string getSet, string propertyName)
+        => CalculateHash($"{getSet}_{propertyName}()");
+
+    public static string GenerateMethodId(IMethodSymbol method)
+        => GenerateMethodId(method.Name, method.Parameters.Select(x => x.Type.ToString()));
+
+    public static string GenerateMethodId(string methodName, IEnumerable<string> parameterTypeNames)
+        => CalculateHash($"{methodName}({string.Join(",", parameterTypeNames)})");
+
+    private static string CalculateHash(string text)
+    {
+        using var sha256 = SHA256.Create();
+
+        var inputBytes = Encoding.UTF8.GetBytes(text);
+        var hashBytes = sha256.ComputeHash(inputBytes);
+
+        return BitConverter.ToString(hashBytes)
+            .Replace("-", "")
+            .Substring(0, 16)
+            .ToLower(CultureInfo.InvariantCulture);
+    }
+}

--- a/src/dotnetCampus.Ipc.Analyzers/SourceGenerators/Models/ClassDeclerationSourceTextBuilder.cs
+++ b/src/dotnetCampus.Ipc.Analyzers/SourceGenerators/Models/ClassDeclerationSourceTextBuilder.cs
@@ -54,11 +54,11 @@ internal class ClassDeclarationSourceTextBuilder
 
     public override string ToString()
     {
-        return $@"{string.Join(Environment.NewLine, _attributeList)}
+        return $@"{string.Join("\r\n", _attributeList)}
 internal class {_typeName} {(_baseTypeNames.Count > 0 ? ":" : "")} {string.Join(", ", _baseTypeNames)}
 {{
     {string.Join(
-        Environment.NewLine,
+        "\r\n",
         _memberBuilders.Select(x => x.ToString()))}
 }}
         ";

--- a/src/dotnetCampus.Ipc.Analyzers/SourceGenerators/Models/MemberDeclerationSourceTextBuilder.cs
+++ b/src/dotnetCampus.Ipc.Analyzers/SourceGenerators/Models/MemberDeclerationSourceTextBuilder.cs
@@ -32,7 +32,7 @@ internal class MemberDeclarationSourceTextBuilder
         {
             return $@"{_sourceCode}
 {{
-    {string.Join(Environment.NewLine, _expressions)}
+    {string.Join("\r\n", _expressions)}
 }}";
         }
     }

--- a/src/dotnetCampus.Ipc.Analyzers/SourceGenerators/Models/SourceTextBuilder.cs
+++ b/src/dotnetCampus.Ipc.Analyzers/SourceGenerators/Models/SourceTextBuilder.cs
@@ -143,7 +143,7 @@ internal class SourceTextBuilder
             builder.Append($"using {usingNamespace.Value};");
         }
         var classes = string.Join(
-            Environment.NewLine,
+            "\r\n",
             _typeDeclarationBuilders.Select(x => x.ToString()));
         if (useFileScopedNamespace)
         {

--- a/src/dotnetCampus.Ipc.Analyzers/SourceGenerators/Utils/GeneratorHelper.cs
+++ b/src/dotnetCampus.Ipc.Analyzers/SourceGenerators/Utils/GeneratorHelper.cs
@@ -113,7 +113,7 @@ internal static class GeneratorHelper
     /// </summary>
     /// <param name="context"></param>
     /// <param name="ex"></param>
-    internal static void ReportDiagnosticsThatHaveNotBeenReported(GeneratorExecutionContext context, DiagnosticException ex)
+    internal static void ReportDiagnosticsThatHaveNotBeenReported(SourceProductionContext context, DiagnosticException ex)
     {
         var diagnosticsThatWillBeReported = new List<DiagnosticDescriptor>
         {

--- a/src/dotnetCampus.Ipc.Analyzers/dotnetCampus.Ipc.Analyzers.csproj
+++ b/src/dotnetCampus.Ipc.Analyzers/dotnetCampus.Ipc.Analyzers.csproj
@@ -9,10 +9,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" />
-    <PackageReference Include="Walterlv.NullableAttributes.Source" Version="7.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
+    <PackageReference Include="Walterlv.NullableAttributes.Source" Version="7.4.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotnetCampus.Ipc.Analyzers/dotnetCampus.Ipc.Analyzers.csproj
+++ b/src/dotnetCampus.Ipc.Analyzers/dotnetCampus.Ipc.Analyzers.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <RootNamespace>dotnetCampus.Ipc</RootNamespace>
     <DefineConstants>$(DefineConstants);IPC_ANALYZER</DefineConstants>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dotnetCampus.Ipc/CompilerServices/GeneratedProxies/GeneratedIpcFactory.cs
+++ b/src/dotnetCampus.Ipc/CompilerServices/GeneratedProxies/GeneratedIpcFactory.cs
@@ -144,7 +144,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
                     .FirstOrDefault(x => x.IpcType == ipcType);
                 if (attribute is null)
                 {
-                    throw new NotSupportedException($"因为编译时没有生成“{ipcType.Name}”代理壳的 IPC 代理类，所以运行时无法创建他们的实例。请确保使用 Visual Studio 2022 或以上版本、MSBuild 17 或以上版本进行编译。");
+                    throw new NotSupportedException($"因为编译时没有生成“{ipcType.Name}”代理壳的 IPC 代理类，所以运行时无法创建它们的实例。请确保使用 Visual Studio 2022 或以上版本、MSBuild 17 或以上版本进行编译。");
                 }
                 return (attribute.ProxyType, null);
             }
@@ -155,7 +155,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
                     .FirstOrDefault(x => x.IpcType == ipcType);
                 if (attribute is null)
                 {
-                    throw new NotSupportedException($"因为编译时没有生成“{ipcType.Name}”接口的 IPC 代理与对接类，所以运行时无法创建他们的实例。请确保使用 Visual Studio 2022 或以上版本、MSBuild 17 或以上版本进行编译。");
+                    throw new NotSupportedException($"因为编译时没有生成“{ipcType.Name}”接口的 IPC 代理与对接类，所以运行时无法创建它们的实例。请确保使用 Visual Studio 2022 或以上版本、MSBuild 17 或以上版本进行编译。");
                 }
                 return (attribute.ProxyType, attribute.JointType);
             }

--- a/src/dotnetCampus.Ipc/CompilerServices/GeneratedProxies/GeneratedIpcJoint.cs
+++ b/src/dotnetCampus.Ipc/CompilerServices/GeneratedProxies/GeneratedIpcJoint.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 using dotnetCampus.Ipc.CompilerServices.GeneratedProxies.Models;
@@ -203,6 +204,42 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
             });
         }
 
+        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7>(string methodName, Action<T1, T2, T3, T4, T5, T6, T7> methodInvoker)
+        {
+            _methods.Add((methodName, 7), args =>
+            {
+                methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!, CastArg<T6>(args![5])!, CastArg<T7>(args![6])!);
+                return default;
+            });
+        }
+
+        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7>(string methodName, Func<T1, T2, T3, T4, T5, T6, T7, Task> methodInvoker)
+        {
+            _asyncMethods.Add((methodName, 7), async args =>
+            {
+                await methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!, CastArg<T6>(args![5])!, CastArg<T7>(args![6])!).ConfigureAwait(false);
+                return default;
+            });
+        }
+
+        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7, T8>(string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8> methodInvoker)
+        {
+            _methods.Add((methodName, 8), args =>
+            {
+                methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!, CastArg<T6>(args![5])!, CastArg<T7>(args![6])!, CastArg<T8>(args![7])!);
+                return default;
+            });
+        }
+
+        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7, T8>(string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, Task> methodInvoker)
+        {
+            _asyncMethods.Add((methodName, 8), async args =>
+            {
+                await methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!, CastArg<T6>(args![5])!, CastArg<T7>(args![6])!, CastArg<T8>(args![7])!).ConfigureAwait(false);
+                return default;
+            });
+        }
+
         protected void MatchMethod<TReturn>(string methodName, Func<Garm<TReturn>> methodInvoker)
         {
             _methods.Add((methodName, 0), _ => CastReturn(methodInvoker()));
@@ -271,6 +308,26 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
         protected void MatchMethod<T1, T2, T3, T4, T5, T6, TReturn>(string methodName, Func<T1, T2, T3, T4, T5, T6, Task<Garm<TReturn>>> methodInvoker)
         {
             _asyncMethods.Add((methodName, 6), async args => CastReturn(await methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!, CastArg<T6>(args![5])!).ConfigureAwait(false)));
+        }
+
+        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7, TReturn>(string methodName, Func<T1, T2, T3, T4, T5, T6, T7, Garm<TReturn>> methodInvoker)
+        {
+            _methods.Add((methodName, 7), args => CastReturn(methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!, CastArg<T6>(args![5])!, CastArg<T7>(args![6])!)));
+        }
+
+        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7, TReturn>(string methodName, Func<T1, T2, T3, T4, T5, T6, T7, Task<Garm<TReturn>>> methodInvoker)
+        {
+            _asyncMethods.Add((methodName, 7), async args => CastReturn(await methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!, CastArg<T6>(args![5])!, CastArg<T7>(args![6])!).ConfigureAwait(false)));
+        }
+
+        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7, T8, TReturn>(string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, Garm<TReturn>> methodInvoker)
+        {
+            _methods.Add((methodName, 8), args => CastReturn(methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!, CastArg<T6>(args![5])!, CastArg<T7>(args![6])!, CastArg<T8>(args![7])!)));
+        }
+
+        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7, T8, TReturn>(string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, Task<Garm<TReturn>>> methodInvoker)
+        {
+            _asyncMethods.Add((methodName, 8), async args => CastReturn(await methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!, CastArg<T6>(args![5])!, CastArg<T7>(args![6])!, CastArg<T8>(args![7])!).ConfigureAwait(false)));
         }
 
         protected void MatchProperty<T>(string propertyName, Func<Garm<T>> getter)

--- a/src/dotnetCampus.Ipc/CompilerServices/GeneratedProxies/GeneratedIpcJoint.cs
+++ b/src/dotnetCampus.Ipc/CompilerServices/GeneratedProxies/GeneratedIpcJoint.cs
@@ -20,10 +20,10 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
         /// </summary>
         /// <param name="realInstance">真实实例。</param>
         internal abstract void SetInstance(object realInstance);
-        internal abstract Garm<object?> GetProperty(string propertyName);
-        internal abstract Garm<object?> SetProperty(string propertyName, object? value);
-        internal abstract Garm<object?> CallMethod(string methodName, object?[]? args);
-        internal abstract Task<Garm<object?>> CallMethodAsync(string methodName, object?[]? args);
+        internal abstract Garm<object?> GetProperty(string memberId, string propertyName);
+        internal abstract Garm<object?> SetProperty(string memberId, string propertyName, object? value);
+        internal abstract Garm<object?> CallMethod(string memberId, string methodName, object?[]? args);
+        internal abstract Task<Garm<object?>> CallMethodAsync(string memberId, string methodName, object?[]? args);
     }
 
     /// <summary>
@@ -38,19 +38,19 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
         private readonly Dictionary<string, Func<Garm<object?>>> _propertyGetters = new();
 
         /// <summary>
-        /// 设置属性值的方法集合。
+        /// 设置属性值的方法集合（Key 为 MemberId，用于标识一个接口内的唯一一个成员，其中属性的 get 和 set 分别是两个不同的成员）。
         /// </summary>
         private readonly Dictionary<string, Action<object?>> _propertySetters = new();
 
         /// <summary>
-        /// 调用方法的方法集合。
+        /// 调用方法的方法集合（Key 为 MemberId，用于标识一个接口内的唯一一个成员，其中属性的 get 和 set 分别是两个不同的成员）。
         /// </summary>
-        private readonly Dictionary<(string methodName, int parameterCount), Func<object?[]?, Garm<object?>>> _methods = new();
+        private readonly Dictionary<string, Func<object?[]?, Garm<object?>>> _methods = new();
 
         /// <summary>
         /// 调用异步方法的方法集合。
         /// </summary>
-        private readonly Dictionary<(string methodName, int parameterCount), Func<object?[]?, Task<Garm<object?>>>> _asyncMethods = new();
+        private readonly Dictionary<string, Func<object?[]?, Task<Garm<object?>>>> _asyncMethods = new();
 
         /// <summary>
         /// 设置此对接对象的真实实例。
@@ -78,281 +78,281 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
         /// <param name="realInstance">当对接时，可使用此参数来访问真实对象。</param>
         protected abstract void MatchMembers(TContract realInstance);
 
-        protected void MatchMethod(string methodName, Action methodInvoker)
+        protected void MatchMethod(string memberId, Action methodInvoker)
         {
-            _methods.Add((methodName, 0), _ =>
+            _methods.Add(memberId, _ =>
             {
                 methodInvoker();
                 return default;
             });
         }
 
-        protected void MatchMethod(string methodName, Func<Task> methodInvoker)
+        protected void MatchMethod(string memberId, Func<Task> methodInvoker)
         {
-            _asyncMethods.Add((methodName, 0), async _ =>
+            _asyncMethods.Add(memberId, async _ =>
             {
                 await methodInvoker().ConfigureAwait(false);
                 return default;
             });
         }
 
-        protected void MatchMethod<T>(string methodName, Action<T> methodInvoker)
+        protected void MatchMethod<T>(string memberId, Action<T> methodInvoker)
         {
-            _methods.Add((methodName, 1), args =>
+            _methods.Add(memberId, args =>
             {
                 methodInvoker(CastArg<T>(args![0])!);
                 return default;
             });
         }
 
-        protected void MatchMethod<T>(string methodName, Func<T, Task> methodInvoker)
+        protected void MatchMethod<T>(string memberId, Func<T, Task> methodInvoker)
         {
-            _asyncMethods.Add((methodName, 1), async args =>
+            _asyncMethods.Add(memberId, async args =>
             {
                 await methodInvoker(CastArg<T>(args![0])!).ConfigureAwait(false);
                 return default;
             });
         }
 
-        protected void MatchMethod<T1, T2>(string methodName, Action<T1, T2> methodInvoker)
+        protected void MatchMethod<T1, T2>(string memberId, Action<T1, T2> methodInvoker)
         {
-            _methods.Add((methodName, 2), args =>
+            _methods.Add(memberId, args =>
             {
                 methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!);
                 return default;
             });
         }
 
-        protected void MatchMethod<T1, T2>(string methodName, Func<T1, T2, Task> methodInvoker)
+        protected void MatchMethod<T1, T2>(string memberId, Func<T1, T2, Task> methodInvoker)
         {
-            _asyncMethods.Add((methodName, 2), async args =>
+            _asyncMethods.Add(memberId, async args =>
             {
                 await methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!).ConfigureAwait(false);
                 return default;
             });
         }
 
-        protected void MatchMethod<T1, T2, T3>(string methodName, Action<T1, T2, T3> methodInvoker)
+        protected void MatchMethod<T1, T2, T3>(string memberId, Action<T1, T2, T3> methodInvoker)
         {
-            _methods.Add((methodName, 3), args =>
+            _methods.Add(memberId, args =>
             {
                 methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!);
                 return default;
             });
         }
 
-        protected void MatchMethod<T1, T2, T3>(string methodName, Func<T1, T2, T3, Task> methodInvoker)
+        protected void MatchMethod<T1, T2, T3>(string memberId, Func<T1, T2, T3, Task> methodInvoker)
         {
-            _asyncMethods.Add((methodName, 3), async args =>
+            _asyncMethods.Add(memberId, async args =>
             {
                 await methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!).ConfigureAwait(false);
                 return default;
             });
         }
 
-        protected void MatchMethod<T1, T2, T3, T4>(string methodName, Action<T1, T2, T3, T4> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4>(string memberId, Action<T1, T2, T3, T4> methodInvoker)
         {
-            _methods.Add((methodName, 4), args =>
+            _methods.Add(memberId, args =>
             {
                 methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!);
                 return default;
             });
         }
 
-        protected void MatchMethod<T1, T2, T3, T4>(string methodName, Func<T1, T2, T3, T4, Task> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4>(string memberId, Func<T1, T2, T3, T4, Task> methodInvoker)
         {
-            _asyncMethods.Add((methodName, 4), async args =>
+            _asyncMethods.Add(memberId, async args =>
             {
                 await methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!).ConfigureAwait(false);
                 return default;
             });
         }
 
-        protected void MatchMethod<T1, T2, T3, T4, T5>(string methodName, Action<T1, T2, T3, T4, T5> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4, T5>(string memberId, Action<T1, T2, T3, T4, T5> methodInvoker)
         {
-            _methods.Add((methodName, 5), args =>
+            _methods.Add(memberId, args =>
             {
                 methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!);
                 return default;
             });
         }
 
-        protected void MatchMethod<T1, T2, T3, T4, T5>(string methodName, Func<T1, T2, T3, T4, T5, Task> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4, T5>(string memberId, Func<T1, T2, T3, T4, T5, Task> methodInvoker)
         {
-            _asyncMethods.Add((methodName, 5), async args =>
+            _asyncMethods.Add(memberId, async args =>
             {
                 await methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!).ConfigureAwait(false);
                 return default;
             });
         }
 
-        protected void MatchMethod<T1, T2, T3, T4, T5, T6>(string methodName, Action<T1, T2, T3, T4, T5, T6> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4, T5, T6>(string memberId, Action<T1, T2, T3, T4, T5, T6> methodInvoker)
         {
-            _methods.Add((methodName, 6), args =>
+            _methods.Add(memberId, args =>
             {
                 methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!, CastArg<T6>(args![5])!);
                 return default;
             });
         }
 
-        protected void MatchMethod<T1, T2, T3, T4, T5, T6>(string methodName, Func<T1, T2, T3, T4, T5, T6, Task> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4, T5, T6>(string memberId, Func<T1, T2, T3, T4, T5, T6, Task> methodInvoker)
         {
-            _asyncMethods.Add((methodName, 6), async args =>
+            _asyncMethods.Add(memberId, async args =>
             {
                 await methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!, CastArg<T6>(args![5])!).ConfigureAwait(false);
                 return default;
             });
         }
 
-        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7>(string methodName, Action<T1, T2, T3, T4, T5, T6, T7> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7>(string memberId, Action<T1, T2, T3, T4, T5, T6, T7> methodInvoker)
         {
-            _methods.Add((methodName, 7), args =>
+            _methods.Add(memberId, args =>
             {
                 methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!, CastArg<T6>(args![5])!, CastArg<T7>(args![6])!);
                 return default;
             });
         }
 
-        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7>(string methodName, Func<T1, T2, T3, T4, T5, T6, T7, Task> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7>(string memberId, Func<T1, T2, T3, T4, T5, T6, T7, Task> methodInvoker)
         {
-            _asyncMethods.Add((methodName, 7), async args =>
+            _asyncMethods.Add(memberId, async args =>
             {
                 await methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!, CastArg<T6>(args![5])!, CastArg<T7>(args![6])!).ConfigureAwait(false);
                 return default;
             });
         }
 
-        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7, T8>(string methodName, Action<T1, T2, T3, T4, T5, T6, T7, T8> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7, T8>(string memberId, Action<T1, T2, T3, T4, T5, T6, T7, T8> methodInvoker)
         {
-            _methods.Add((methodName, 8), args =>
+            _methods.Add(memberId, args =>
             {
                 methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!, CastArg<T6>(args![5])!, CastArg<T7>(args![6])!, CastArg<T8>(args![7])!);
                 return default;
             });
         }
 
-        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7, T8>(string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, Task> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7, T8>(string memberId, Func<T1, T2, T3, T4, T5, T6, T7, T8, Task> methodInvoker)
         {
-            _asyncMethods.Add((methodName, 8), async args =>
+            _asyncMethods.Add(memberId, async args =>
             {
                 await methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!, CastArg<T6>(args![5])!, CastArg<T7>(args![6])!, CastArg<T8>(args![7])!).ConfigureAwait(false);
                 return default;
             });
         }
 
-        protected void MatchMethod<TReturn>(string methodName, Func<Garm<TReturn>> methodInvoker)
+        protected void MatchMethod<TReturn>(string memberId, Func<Garm<TReturn>> methodInvoker)
         {
-            _methods.Add((methodName, 0), _ => CastReturn(methodInvoker()));
+            _methods.Add(memberId, _ => CastReturn(methodInvoker()));
         }
 
-        protected void MatchMethod<TReturn>(string methodName, Func<Task<Garm<TReturn>>> methodInvoker)
+        protected void MatchMethod<TReturn>(string memberId, Func<Task<Garm<TReturn>>> methodInvoker)
         {
-            _asyncMethods.Add((methodName, 0), async _ => CastReturn(await methodInvoker().ConfigureAwait(false)));
+            _asyncMethods.Add(memberId, async _ => CastReturn(await methodInvoker().ConfigureAwait(false)));
         }
 
-        protected void MatchMethod<T, TReturn>(string methodName, Func<T, Garm<TReturn>> methodInvoker)
+        protected void MatchMethod<T, TReturn>(string memberId, Func<T, Garm<TReturn>> methodInvoker)
         {
-            _methods.Add((methodName, 1), args => CastReturn(methodInvoker(CastArg<T>(args![0])!)));
+            _methods.Add(memberId, args => CastReturn(methodInvoker(CastArg<T>(args![0])!)));
         }
 
-        protected void MatchMethod<T, TReturn>(string methodName, Func<T, Task<Garm<TReturn>>> methodInvoker)
+        protected void MatchMethod<T, TReturn>(string memberId, Func<T, Task<Garm<TReturn>>> methodInvoker)
         {
-            _asyncMethods.Add((methodName, 1), async args => CastReturn(await methodInvoker(CastArg<T>(args![0])!).ConfigureAwait(false)));
+            _asyncMethods.Add(memberId, async args => CastReturn(await methodInvoker(CastArg<T>(args![0])!).ConfigureAwait(false)));
         }
 
-        protected void MatchMethod<T1, T2, TReturn>(string methodName, Func<T1, T2, Garm<TReturn>> methodInvoker)
+        protected void MatchMethod<T1, T2, TReturn>(string memberId, Func<T1, T2, Garm<TReturn>> methodInvoker)
         {
-            _methods.Add((methodName, 2), args => CastReturn(methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!)));
+            _methods.Add(memberId, args => CastReturn(methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!)));
         }
 
-        protected void MatchMethod<T1, T2, TReturn>(string methodName, Func<T1, T2, Task<Garm<TReturn>>> methodInvoker)
+        protected void MatchMethod<T1, T2, TReturn>(string memberId, Func<T1, T2, Task<Garm<TReturn>>> methodInvoker)
         {
-            _asyncMethods.Add((methodName, 2), async args => CastReturn(await methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!).ConfigureAwait(false)));
+            _asyncMethods.Add(memberId, async args => CastReturn(await methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!).ConfigureAwait(false)));
         }
 
-        protected void MatchMethod<T1, T2, T3, TReturn>(string methodName, Func<T1, T2, T3, Garm<TReturn>> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, TReturn>(string memberId, Func<T1, T2, T3, Garm<TReturn>> methodInvoker)
         {
-            _methods.Add((methodName, 3), args => CastReturn(methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!)));
+            _methods.Add(memberId, args => CastReturn(methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!)));
         }
 
-        protected void MatchMethod<T1, T2, T3, TReturn>(string methodName, Func<T1, T2, T3, Task<Garm<TReturn>>> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, TReturn>(string memberId, Func<T1, T2, T3, Task<Garm<TReturn>>> methodInvoker)
         {
-            _asyncMethods.Add((methodName, 3), async args => CastReturn(await methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!).ConfigureAwait(false)));
+            _asyncMethods.Add(memberId, async args => CastReturn(await methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!).ConfigureAwait(false)));
         }
 
-        protected void MatchMethod<T1, T2, T3, T4, TReturn>(string methodName, Func<T1, T2, T3, T4, Garm<TReturn>> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4, TReturn>(string memberId, Func<T1, T2, T3, T4, Garm<TReturn>> methodInvoker)
         {
-            _methods.Add((methodName, 4), args => CastReturn(methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!)));
+            _methods.Add(memberId, args => CastReturn(methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!)));
         }
 
-        protected void MatchMethod<T1, T2, T3, T4, TReturn>(string methodName, Func<T1, T2, T3, T4, Task<Garm<TReturn>>> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4, TReturn>(string memberId, Func<T1, T2, T3, T4, Task<Garm<TReturn>>> methodInvoker)
         {
-            _asyncMethods.Add((methodName, 4), async args => CastReturn(await methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!).ConfigureAwait(false)));
+            _asyncMethods.Add(memberId, async args => CastReturn(await methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!).ConfigureAwait(false)));
         }
 
-        protected void MatchMethod<T1, T2, T3, T4, T5, TReturn>(string methodName, Func<T1, T2, T3, T4, T5, Garm<TReturn>> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4, T5, TReturn>(string memberId, Func<T1, T2, T3, T4, T5, Garm<TReturn>> methodInvoker)
         {
-            _methods.Add((methodName, 5), args => CastReturn(methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!)));
+            _methods.Add(memberId, args => CastReturn(methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!)));
         }
 
-        protected void MatchMethod<T1, T2, T3, T4, T5, TReturn>(string methodName, Func<T1, T2, T3, T4, T5, Task<Garm<TReturn>>> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4, T5, TReturn>(string memberId, Func<T1, T2, T3, T4, T5, Task<Garm<TReturn>>> methodInvoker)
         {
-            _asyncMethods.Add((methodName, 5), async args => CastReturn(await methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!).ConfigureAwait(false)));
+            _asyncMethods.Add(memberId, async args => CastReturn(await methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!).ConfigureAwait(false)));
         }
 
-        protected void MatchMethod<T1, T2, T3, T4, T5, T6, TReturn>(string methodName, Func<T1, T2, T3, T4, T5, T6, Garm<TReturn>> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4, T5, T6, TReturn>(string memberId, Func<T1, T2, T3, T4, T5, T6, Garm<TReturn>> methodInvoker)
         {
-            _methods.Add((methodName, 6), args => CastReturn(methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!, CastArg<T6>(args![5])!)));
+            _methods.Add(memberId, args => CastReturn(methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!, CastArg<T6>(args![5])!)));
         }
 
-        protected void MatchMethod<T1, T2, T3, T4, T5, T6, TReturn>(string methodName, Func<T1, T2, T3, T4, T5, T6, Task<Garm<TReturn>>> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4, T5, T6, TReturn>(string memberId, Func<T1, T2, T3, T4, T5, T6, Task<Garm<TReturn>>> methodInvoker)
         {
-            _asyncMethods.Add((methodName, 6), async args => CastReturn(await methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!, CastArg<T6>(args![5])!).ConfigureAwait(false)));
+            _asyncMethods.Add(memberId, async args => CastReturn(await methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!, CastArg<T6>(args![5])!).ConfigureAwait(false)));
         }
 
-        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7, TReturn>(string methodName, Func<T1, T2, T3, T4, T5, T6, T7, Garm<TReturn>> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7, TReturn>(string memberId, Func<T1, T2, T3, T4, T5, T6, T7, Garm<TReturn>> methodInvoker)
         {
-            _methods.Add((methodName, 7), args => CastReturn(methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!, CastArg<T6>(args![5])!, CastArg<T7>(args![6])!)));
+            _methods.Add(memberId, args => CastReturn(methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!, CastArg<T6>(args![5])!, CastArg<T7>(args![6])!)));
         }
 
-        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7, TReturn>(string methodName, Func<T1, T2, T3, T4, T5, T6, T7, Task<Garm<TReturn>>> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7, TReturn>(string memberId, Func<T1, T2, T3, T4, T5, T6, T7, Task<Garm<TReturn>>> methodInvoker)
         {
-            _asyncMethods.Add((methodName, 7), async args => CastReturn(await methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!, CastArg<T6>(args![5])!, CastArg<T7>(args![6])!).ConfigureAwait(false)));
+            _asyncMethods.Add(memberId, async args => CastReturn(await methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!, CastArg<T6>(args![5])!, CastArg<T7>(args![6])!).ConfigureAwait(false)));
         }
 
-        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7, T8, TReturn>(string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, Garm<TReturn>> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7, T8, TReturn>(string memberId, Func<T1, T2, T3, T4, T5, T6, T7, T8, Garm<TReturn>> methodInvoker)
         {
-            _methods.Add((methodName, 8), args => CastReturn(methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!, CastArg<T6>(args![5])!, CastArg<T7>(args![6])!, CastArg<T8>(args![7])!)));
+            _methods.Add(memberId, args => CastReturn(methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!, CastArg<T6>(args![5])!, CastArg<T7>(args![6])!, CastArg<T8>(args![7])!)));
         }
 
-        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7, T8, TReturn>(string methodName, Func<T1, T2, T3, T4, T5, T6, T7, T8, Task<Garm<TReturn>>> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7, T8, TReturn>(string memberId, Func<T1, T2, T3, T4, T5, T6, T7, T8, Task<Garm<TReturn>>> methodInvoker)
         {
-            _asyncMethods.Add((methodName, 8), async args => CastReturn(await methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!, CastArg<T6>(args![5])!, CastArg<T7>(args![6])!, CastArg<T8>(args![7])!).ConfigureAwait(false)));
+            _asyncMethods.Add(memberId, async args => CastReturn(await methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!, CastArg<T6>(args![5])!, CastArg<T7>(args![6])!, CastArg<T8>(args![7])!).ConfigureAwait(false)));
         }
 
-        protected void MatchProperty<T>(string propertyName, Func<Garm<T>> getter)
+        protected void MatchProperty<T>(string getPropertyId, Func<Garm<T>> getter)
         {
-            _propertyGetters.Add(propertyName, () => CastReturn(getter()));
+            _propertyGetters.Add(getPropertyId, () => CastReturn(getter()));
         }
 
-        protected void MatchProperty<T>(string propertyName, Func<Garm<T>> getter, Action<T> setter)
+        protected void MatchProperty<T>(string getPropertyId, string setPropertyId, Func<Garm<T>> getter, Action<T> setter)
         {
-            _propertyGetters.Add(propertyName, () => CastReturn(getter()));
-            _propertySetters.Add(propertyName, value => setter(CastArg<T>(value)!));
+            _propertyGetters.Add(getPropertyId, () => CastReturn(getter()));
+            _propertySetters.Add(setPropertyId, value => setter(CastArg<T>(value)!));
         }
 
-        internal sealed override Garm<object?> GetProperty(string propertyName)
+        internal sealed override Garm<object?> GetProperty(string memberId, string propertyName)
         {
-            if (_propertyGetters.TryGetValue(propertyName, out var getter))
+            if (_propertyGetters.TryGetValue(memberId, out var getter))
             {
                 return getter();
             }
             throw new NotImplementedException($"无法对接 {typeof(TContract).FullName}.{propertyName} 属性，因为没有在 {GetType().FullName} 的 IPC 对接类中进行匹配。");
         }
 
-        internal sealed override Garm<object?> SetProperty(string propertyName, object? value)
+        internal sealed override Garm<object?> SetProperty(string memberId, string propertyName, object? value)
         {
-            if (_propertySetters.TryGetValue(propertyName, out var setter))
+            if (_propertySetters.TryGetValue(memberId, out var setter))
             {
                 setter(value);
                 return default;
@@ -360,24 +360,24 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
             throw new NotImplementedException($"无法对接 {typeof(TContract).FullName}.{propertyName} 属性，因为没有在 {GetType().FullName} 的 IPC 对接类中进行匹配。");
         }
 
-        internal sealed override Garm<object?> CallMethod(string methodName, object?[]? args)
+        internal sealed override Garm<object?> CallMethod(string memberId, string methodName, object?[]? args)
         {
             var count = args is null ? 0 : args.Length;
-            if (_methods.TryGetValue((methodName, count), out var method))
+            if (_methods.TryGetValue(memberId, out var method))
             {
                 return method(args);
             }
-            throw CreateMethodNotMatchException(methodName, count);
+            throw CreateMethodNotMatchException(memberId, methodName);
         }
 
-        internal sealed override async Task<Garm<object?>> CallMethodAsync(string methodName, object?[]? args)
+        internal sealed override async Task<Garm<object?>> CallMethodAsync(string memberId, string methodName, object?[]? args)
         {
             var count = args is null ? 0 : args.Length;
-            if (_asyncMethods.TryGetValue((methodName, count), out var asyncMethod))
+            if (_asyncMethods.TryGetValue(memberId, out var asyncMethod))
             {
                 return await asyncMethod(args).ConfigureAwait(false);
             }
-            throw CreateMethodNotMatchException(methodName, count);
+            throw CreateMethodNotMatchException(memberId, methodName);
         }
 
         private T? CastArg<T>(object? argModel)
@@ -394,22 +394,9 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
             return new Garm<object?>(argModel.Value, argModel.IpcType);
         }
 
-        private Exception CreateMethodNotMatchException(string methodName, int count)
+        private Exception CreateMethodNotMatchException(string memberId, string methodName)
         {
-            var methodPair = _methods.FirstOrDefault(pair => pair.Key.methodName == methodName);
-            var asyncMethodPair = _asyncMethods.FirstOrDefault(pair => pair.Key.methodName == methodName);
-            if (methodPair.Key.parameterCount != count)
-            {
-                return new NotImplementedException($"无法对接 {typeof(TContract).FullName}.{methodName}({count} 个参数) 方法，在 {GetType().FullName} 中能找到的 IPC 对接类中最接近的是 {methodPair.Key.parameterCount} 个参数的重载。");
-            }
-            else if (asyncMethodPair.Key.parameterCount != count)
-            {
-                return new NotImplementedException($"无法对接 {typeof(TContract).FullName}.{methodName}({count} 个参数) 方法，在 {GetType().FullName} 中能找到的 IPC 对接类中最接近的是 {asyncMethodPair.Key.parameterCount} 个参数的异步重载。");
-            }
-            else
-            {
-                return new NotImplementedException($"无法对接 {typeof(TContract).FullName}.{methodName} 方法，因为没有在 {GetType().FullName} 的 IPC 对接类中进行匹配。");
-            }
+            return new NotImplementedException($"无法对接 Id 为 {memberId} 的 {typeof(TContract).FullName}.{methodName} 方法，因为没有在 {GetType().FullName} 的 IPC 对接类中进行匹配。");
         }
     }
 }

--- a/src/dotnetCampus.Ipc/CompilerServices/GeneratedProxies/GeneratedIpcJoint.cs
+++ b/src/dotnetCampus.Ipc/CompilerServices/GeneratedProxies/GeneratedIpcJoint.cs
@@ -20,10 +20,10 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
         /// </summary>
         /// <param name="realInstance">真实实例。</param>
         internal abstract void SetInstance(object realInstance);
-        internal abstract Garm<object?> GetProperty(string memberId, string propertyName);
-        internal abstract Garm<object?> SetProperty(string memberId, string propertyName, object? value);
-        internal abstract Garm<object?> CallMethod(string memberId, string methodName, object?[]? args);
-        internal abstract Task<Garm<object?>> CallMethodAsync(string memberId, string methodName, object?[]? args);
+        internal abstract Garm<object?> GetProperty(ulong memberId, string propertyName);
+        internal abstract Garm<object?> SetProperty(ulong memberId, string propertyName, object? value);
+        internal abstract Garm<object?> CallMethod(ulong memberId, string methodName, object?[]? args);
+        internal abstract Task<Garm<object?>> CallMethodAsync(ulong memberId, string methodName, object?[]? args);
     }
 
     /// <summary>
@@ -35,22 +35,22 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
         /// <summary>
         /// 获取属性值的方法集合。
         /// </summary>
-        private readonly Dictionary<string, Func<Garm<object?>>> _propertyGetters = new();
+        private readonly Dictionary<ulong, Func<Garm<object?>>> _propertyGetters = new();
 
         /// <summary>
         /// 设置属性值的方法集合（Key 为 MemberId，用于标识一个接口内的唯一一个成员，其中属性的 get 和 set 分别是两个不同的成员）。
         /// </summary>
-        private readonly Dictionary<string, Action<object?>> _propertySetters = new();
+        private readonly Dictionary<ulong, Action<object?>> _propertySetters = new();
 
         /// <summary>
         /// 调用方法的方法集合（Key 为 MemberId，用于标识一个接口内的唯一一个成员，其中属性的 get 和 set 分别是两个不同的成员）。
         /// </summary>
-        private readonly Dictionary<string, Func<object?[]?, Garm<object?>>> _methods = new();
+        private readonly Dictionary<ulong, Func<object?[]?, Garm<object?>>> _methods = new();
 
         /// <summary>
         /// 调用异步方法的方法集合。
         /// </summary>
-        private readonly Dictionary<string, Func<object?[]?, Task<Garm<object?>>>> _asyncMethods = new();
+        private readonly Dictionary<ulong, Func<object?[]?, Task<Garm<object?>>>> _asyncMethods = new();
 
         /// <summary>
         /// 设置此对接对象的真实实例。
@@ -78,7 +78,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
         /// <param name="realInstance">当对接时，可使用此参数来访问真实对象。</param>
         protected abstract void MatchMembers(TContract realInstance);
 
-        protected void MatchMethod(string memberId, Action methodInvoker)
+        protected void MatchMethod(ulong memberId, Action methodInvoker)
         {
             _methods.Add(memberId, _ =>
             {
@@ -87,7 +87,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
             });
         }
 
-        protected void MatchMethod(string memberId, Func<Task> methodInvoker)
+        protected void MatchMethod(ulong memberId, Func<Task> methodInvoker)
         {
             _asyncMethods.Add(memberId, async _ =>
             {
@@ -96,7 +96,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
             });
         }
 
-        protected void MatchMethod<T>(string memberId, Action<T> methodInvoker)
+        protected void MatchMethod<T>(ulong memberId, Action<T> methodInvoker)
         {
             _methods.Add(memberId, args =>
             {
@@ -105,7 +105,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
             });
         }
 
-        protected void MatchMethod<T>(string memberId, Func<T, Task> methodInvoker)
+        protected void MatchMethod<T>(ulong memberId, Func<T, Task> methodInvoker)
         {
             _asyncMethods.Add(memberId, async args =>
             {
@@ -114,7 +114,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
             });
         }
 
-        protected void MatchMethod<T1, T2>(string memberId, Action<T1, T2> methodInvoker)
+        protected void MatchMethod<T1, T2>(ulong memberId, Action<T1, T2> methodInvoker)
         {
             _methods.Add(memberId, args =>
             {
@@ -123,7 +123,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
             });
         }
 
-        protected void MatchMethod<T1, T2>(string memberId, Func<T1, T2, Task> methodInvoker)
+        protected void MatchMethod<T1, T2>(ulong memberId, Func<T1, T2, Task> methodInvoker)
         {
             _asyncMethods.Add(memberId, async args =>
             {
@@ -132,7 +132,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
             });
         }
 
-        protected void MatchMethod<T1, T2, T3>(string memberId, Action<T1, T2, T3> methodInvoker)
+        protected void MatchMethod<T1, T2, T3>(ulong memberId, Action<T1, T2, T3> methodInvoker)
         {
             _methods.Add(memberId, args =>
             {
@@ -141,7 +141,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
             });
         }
 
-        protected void MatchMethod<T1, T2, T3>(string memberId, Func<T1, T2, T3, Task> methodInvoker)
+        protected void MatchMethod<T1, T2, T3>(ulong memberId, Func<T1, T2, T3, Task> methodInvoker)
         {
             _asyncMethods.Add(memberId, async args =>
             {
@@ -150,7 +150,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
             });
         }
 
-        protected void MatchMethod<T1, T2, T3, T4>(string memberId, Action<T1, T2, T3, T4> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4>(ulong memberId, Action<T1, T2, T3, T4> methodInvoker)
         {
             _methods.Add(memberId, args =>
             {
@@ -159,7 +159,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
             });
         }
 
-        protected void MatchMethod<T1, T2, T3, T4>(string memberId, Func<T1, T2, T3, T4, Task> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4>(ulong memberId, Func<T1, T2, T3, T4, Task> methodInvoker)
         {
             _asyncMethods.Add(memberId, async args =>
             {
@@ -168,7 +168,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
             });
         }
 
-        protected void MatchMethod<T1, T2, T3, T4, T5>(string memberId, Action<T1, T2, T3, T4, T5> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4, T5>(ulong memberId, Action<T1, T2, T3, T4, T5> methodInvoker)
         {
             _methods.Add(memberId, args =>
             {
@@ -177,7 +177,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
             });
         }
 
-        protected void MatchMethod<T1, T2, T3, T4, T5>(string memberId, Func<T1, T2, T3, T4, T5, Task> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4, T5>(ulong memberId, Func<T1, T2, T3, T4, T5, Task> methodInvoker)
         {
             _asyncMethods.Add(memberId, async args =>
             {
@@ -186,7 +186,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
             });
         }
 
-        protected void MatchMethod<T1, T2, T3, T4, T5, T6>(string memberId, Action<T1, T2, T3, T4, T5, T6> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4, T5, T6>(ulong memberId, Action<T1, T2, T3, T4, T5, T6> methodInvoker)
         {
             _methods.Add(memberId, args =>
             {
@@ -195,7 +195,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
             });
         }
 
-        protected void MatchMethod<T1, T2, T3, T4, T5, T6>(string memberId, Func<T1, T2, T3, T4, T5, T6, Task> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4, T5, T6>(ulong memberId, Func<T1, T2, T3, T4, T5, T6, Task> methodInvoker)
         {
             _asyncMethods.Add(memberId, async args =>
             {
@@ -204,7 +204,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
             });
         }
 
-        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7>(string memberId, Action<T1, T2, T3, T4, T5, T6, T7> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7>(ulong memberId, Action<T1, T2, T3, T4, T5, T6, T7> methodInvoker)
         {
             _methods.Add(memberId, args =>
             {
@@ -213,7 +213,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
             });
         }
 
-        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7>(string memberId, Func<T1, T2, T3, T4, T5, T6, T7, Task> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7>(ulong memberId, Func<T1, T2, T3, T4, T5, T6, T7, Task> methodInvoker)
         {
             _asyncMethods.Add(memberId, async args =>
             {
@@ -222,7 +222,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
             });
         }
 
-        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7, T8>(string memberId, Action<T1, T2, T3, T4, T5, T6, T7, T8> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7, T8>(ulong memberId, Action<T1, T2, T3, T4, T5, T6, T7, T8> methodInvoker)
         {
             _methods.Add(memberId, args =>
             {
@@ -231,7 +231,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
             });
         }
 
-        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7, T8>(string memberId, Func<T1, T2, T3, T4, T5, T6, T7, T8, Task> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7, T8>(ulong memberId, Func<T1, T2, T3, T4, T5, T6, T7, T8, Task> methodInvoker)
         {
             _asyncMethods.Add(memberId, async args =>
             {
@@ -240,108 +240,108 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
             });
         }
 
-        protected void MatchMethod<TReturn>(string memberId, Func<Garm<TReturn>> methodInvoker)
+        protected void MatchMethod<TReturn>(ulong memberId, Func<Garm<TReturn>> methodInvoker)
         {
             _methods.Add(memberId, _ => CastReturn(methodInvoker()));
         }
 
-        protected void MatchMethod<TReturn>(string memberId, Func<Task<Garm<TReturn>>> methodInvoker)
+        protected void MatchMethod<TReturn>(ulong memberId, Func<Task<Garm<TReturn>>> methodInvoker)
         {
             _asyncMethods.Add(memberId, async _ => CastReturn(await methodInvoker().ConfigureAwait(false)));
         }
 
-        protected void MatchMethod<T, TReturn>(string memberId, Func<T, Garm<TReturn>> methodInvoker)
+        protected void MatchMethod<T, TReturn>(ulong memberId, Func<T, Garm<TReturn>> methodInvoker)
         {
             _methods.Add(memberId, args => CastReturn(methodInvoker(CastArg<T>(args![0])!)));
         }
 
-        protected void MatchMethod<T, TReturn>(string memberId, Func<T, Task<Garm<TReturn>>> methodInvoker)
+        protected void MatchMethod<T, TReturn>(ulong memberId, Func<T, Task<Garm<TReturn>>> methodInvoker)
         {
             _asyncMethods.Add(memberId, async args => CastReturn(await methodInvoker(CastArg<T>(args![0])!).ConfigureAwait(false)));
         }
 
-        protected void MatchMethod<T1, T2, TReturn>(string memberId, Func<T1, T2, Garm<TReturn>> methodInvoker)
+        protected void MatchMethod<T1, T2, TReturn>(ulong memberId, Func<T1, T2, Garm<TReturn>> methodInvoker)
         {
             _methods.Add(memberId, args => CastReturn(methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!)));
         }
 
-        protected void MatchMethod<T1, T2, TReturn>(string memberId, Func<T1, T2, Task<Garm<TReturn>>> methodInvoker)
+        protected void MatchMethod<T1, T2, TReturn>(ulong memberId, Func<T1, T2, Task<Garm<TReturn>>> methodInvoker)
         {
             _asyncMethods.Add(memberId, async args => CastReturn(await methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!).ConfigureAwait(false)));
         }
 
-        protected void MatchMethod<T1, T2, T3, TReturn>(string memberId, Func<T1, T2, T3, Garm<TReturn>> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, TReturn>(ulong memberId, Func<T1, T2, T3, Garm<TReturn>> methodInvoker)
         {
             _methods.Add(memberId, args => CastReturn(methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!)));
         }
 
-        protected void MatchMethod<T1, T2, T3, TReturn>(string memberId, Func<T1, T2, T3, Task<Garm<TReturn>>> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, TReturn>(ulong memberId, Func<T1, T2, T3, Task<Garm<TReturn>>> methodInvoker)
         {
             _asyncMethods.Add(memberId, async args => CastReturn(await methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!).ConfigureAwait(false)));
         }
 
-        protected void MatchMethod<T1, T2, T3, T4, TReturn>(string memberId, Func<T1, T2, T3, T4, Garm<TReturn>> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4, TReturn>(ulong memberId, Func<T1, T2, T3, T4, Garm<TReturn>> methodInvoker)
         {
             _methods.Add(memberId, args => CastReturn(methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!)));
         }
 
-        protected void MatchMethod<T1, T2, T3, T4, TReturn>(string memberId, Func<T1, T2, T3, T4, Task<Garm<TReturn>>> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4, TReturn>(ulong memberId, Func<T1, T2, T3, T4, Task<Garm<TReturn>>> methodInvoker)
         {
             _asyncMethods.Add(memberId, async args => CastReturn(await methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!).ConfigureAwait(false)));
         }
 
-        protected void MatchMethod<T1, T2, T3, T4, T5, TReturn>(string memberId, Func<T1, T2, T3, T4, T5, Garm<TReturn>> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4, T5, TReturn>(ulong memberId, Func<T1, T2, T3, T4, T5, Garm<TReturn>> methodInvoker)
         {
             _methods.Add(memberId, args => CastReturn(methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!)));
         }
 
-        protected void MatchMethod<T1, T2, T3, T4, T5, TReturn>(string memberId, Func<T1, T2, T3, T4, T5, Task<Garm<TReturn>>> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4, T5, TReturn>(ulong memberId, Func<T1, T2, T3, T4, T5, Task<Garm<TReturn>>> methodInvoker)
         {
             _asyncMethods.Add(memberId, async args => CastReturn(await methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!).ConfigureAwait(false)));
         }
 
-        protected void MatchMethod<T1, T2, T3, T4, T5, T6, TReturn>(string memberId, Func<T1, T2, T3, T4, T5, T6, Garm<TReturn>> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4, T5, T6, TReturn>(ulong memberId, Func<T1, T2, T3, T4, T5, T6, Garm<TReturn>> methodInvoker)
         {
             _methods.Add(memberId, args => CastReturn(methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!, CastArg<T6>(args![5])!)));
         }
 
-        protected void MatchMethod<T1, T2, T3, T4, T5, T6, TReturn>(string memberId, Func<T1, T2, T3, T4, T5, T6, Task<Garm<TReturn>>> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4, T5, T6, TReturn>(ulong memberId, Func<T1, T2, T3, T4, T5, T6, Task<Garm<TReturn>>> methodInvoker)
         {
             _asyncMethods.Add(memberId, async args => CastReturn(await methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!, CastArg<T6>(args![5])!).ConfigureAwait(false)));
         }
 
-        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7, TReturn>(string memberId, Func<T1, T2, T3, T4, T5, T6, T7, Garm<TReturn>> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7, TReturn>(ulong memberId, Func<T1, T2, T3, T4, T5, T6, T7, Garm<TReturn>> methodInvoker)
         {
             _methods.Add(memberId, args => CastReturn(methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!, CastArg<T6>(args![5])!, CastArg<T7>(args![6])!)));
         }
 
-        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7, TReturn>(string memberId, Func<T1, T2, T3, T4, T5, T6, T7, Task<Garm<TReturn>>> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7, TReturn>(ulong memberId, Func<T1, T2, T3, T4, T5, T6, T7, Task<Garm<TReturn>>> methodInvoker)
         {
             _asyncMethods.Add(memberId, async args => CastReturn(await methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!, CastArg<T6>(args![5])!, CastArg<T7>(args![6])!).ConfigureAwait(false)));
         }
 
-        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7, T8, TReturn>(string memberId, Func<T1, T2, T3, T4, T5, T6, T7, T8, Garm<TReturn>> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7, T8, TReturn>(ulong memberId, Func<T1, T2, T3, T4, T5, T6, T7, T8, Garm<TReturn>> methodInvoker)
         {
             _methods.Add(memberId, args => CastReturn(methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!, CastArg<T6>(args![5])!, CastArg<T7>(args![6])!, CastArg<T8>(args![7])!)));
         }
 
-        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7, T8, TReturn>(string memberId, Func<T1, T2, T3, T4, T5, T6, T7, T8, Task<Garm<TReturn>>> methodInvoker)
+        protected void MatchMethod<T1, T2, T3, T4, T5, T6, T7, T8, TReturn>(ulong memberId, Func<T1, T2, T3, T4, T5, T6, T7, T8, Task<Garm<TReturn>>> methodInvoker)
         {
             _asyncMethods.Add(memberId, async args => CastReturn(await methodInvoker(CastArg<T1>(args![0])!, CastArg<T2>(args![1])!, CastArg<T3>(args![2])!, CastArg<T4>(args![3])!, CastArg<T5>(args![4])!, CastArg<T6>(args![5])!, CastArg<T7>(args![6])!, CastArg<T8>(args![7])!).ConfigureAwait(false)));
         }
 
-        protected void MatchProperty<T>(string getPropertyId, Func<Garm<T>> getter)
+        protected void MatchProperty<T>(ulong getPropertyId, Func<Garm<T>> getter)
         {
             _propertyGetters.Add(getPropertyId, () => CastReturn(getter()));
         }
 
-        protected void MatchProperty<T>(string getPropertyId, string setPropertyId, Func<Garm<T>> getter, Action<T> setter)
+        protected void MatchProperty<T>(ulong getPropertyId, ulong setPropertyId, Func<Garm<T>> getter, Action<T> setter)
         {
             _propertyGetters.Add(getPropertyId, () => CastReturn(getter()));
             _propertySetters.Add(setPropertyId, value => setter(CastArg<T>(value)!));
         }
 
-        internal sealed override Garm<object?> GetProperty(string memberId, string propertyName)
+        internal sealed override Garm<object?> GetProperty(ulong memberId, string propertyName)
         {
             if (_propertyGetters.TryGetValue(memberId, out var getter))
             {
@@ -350,7 +350,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
             throw new NotImplementedException($"无法对接 {typeof(TContract).FullName}.{propertyName} 属性，因为没有在 {GetType().FullName} 的 IPC 对接类中进行匹配。");
         }
 
-        internal sealed override Garm<object?> SetProperty(string memberId, string propertyName, object? value)
+        internal sealed override Garm<object?> SetProperty(ulong memberId, string propertyName, object? value)
         {
             if (_propertySetters.TryGetValue(memberId, out var setter))
             {
@@ -360,7 +360,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
             throw new NotImplementedException($"无法对接 {typeof(TContract).FullName}.{propertyName} 属性，因为没有在 {GetType().FullName} 的 IPC 对接类中进行匹配。");
         }
 
-        internal sealed override Garm<object?> CallMethod(string memberId, string methodName, object?[]? args)
+        internal sealed override Garm<object?> CallMethod(ulong memberId, string methodName, object?[]? args)
         {
             var count = args is null ? 0 : args.Length;
             if (_methods.TryGetValue(memberId, out var method))
@@ -370,7 +370,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
             throw CreateMethodNotMatchException(memberId, methodName);
         }
 
-        internal sealed override async Task<Garm<object?>> CallMethodAsync(string memberId, string methodName, object?[]? args)
+        internal sealed override async Task<Garm<object?>> CallMethodAsync(ulong memberId, string methodName, object?[]? args)
         {
             var count = args is null ? 0 : args.Length;
             if (_asyncMethods.TryGetValue(memberId, out var asyncMethod))
@@ -394,7 +394,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
             return new Garm<object?>(argModel.Value, argModel.IpcType);
         }
 
-        private Exception CreateMethodNotMatchException(string memberId, string methodName)
+        private Exception CreateMethodNotMatchException(ulong memberId, string methodName)
         {
             return new NotImplementedException($"无法对接 Id 为 {memberId} 的 {typeof(TContract).FullName}.{methodName} 方法，因为没有在 {GetType().FullName} 的 IPC 对接类中进行匹配。");
         }

--- a/src/dotnetCampus.Ipc/CompilerServices/GeneratedProxies/GeneratedIpcProxy.cs
+++ b/src/dotnetCampus.Ipc/CompilerServices/GeneratedProxies/GeneratedIpcProxy.cs
@@ -86,7 +86,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
         /// <param name="namedValues">包含属性上标记的调用此 IPC 属性的个性化方式。</param>
         /// <param name="propertyName">属性名称。</param>
         /// <returns>可异步等待的属性的值。</returns>
-        protected async Task<T?> GetValueAsync<T>(IpcProxyMemberNamedValues namedValues, [CallerMemberName] string propertyName = "")
+        protected async Task<T?> GetValueAsync<T>(string memberId, IpcProxyMemberNamedValues namedValues, [CallerMemberName] string propertyName = "")
         {
             if (namedValues.IsReadonly ?? false)
             {
@@ -98,13 +98,13 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
                     return (T?) cachedValue;
                 }
                 // 否则，通过 IPC 访问获取此属性的值后设入缓存。（这里可能存在并发情况，会导致浪费的 IPC 访问，但能确保数据一致性）。
-                var value = await IpcInvokeAsync<T>(MemberInvokingType.GetProperty, propertyName, null, namedValues).ConfigureAwait(false);
+                var value = await IpcInvokeAsync<T>(MemberInvokingType.GetProperty, memberId, propertyName, null, namedValues).ConfigureAwait(false);
                 _readonlyPropertyValues.TryAdd(propertyName, value);
                 return value;
             }
             else
             {
-                return await IpcInvokeAsync<T>(MemberInvokingType.GetProperty, propertyName, null, namedValues).ConfigureAwait(false);
+                return await IpcInvokeAsync<T>(MemberInvokingType.GetProperty, memberId, propertyName, null, namedValues).ConfigureAwait(false);
             }
         }
 
@@ -116,9 +116,9 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
         /// <param name="namedValues">包含属性上标记的调用此 IPC 属性的个性化方式。</param>
         /// <param name="propertyName">属性名称。</param>
         /// <returns>可异步等待的属性设置。</returns>
-        protected Task SetValueAsync<T>(Garm<T> value, IpcProxyMemberNamedValues namedValues, [CallerMemberName] string propertyName = "")
+        protected Task SetValueAsync<T>(string memberId, Garm<T> value, IpcProxyMemberNamedValues namedValues, [CallerMemberName] string propertyName = "")
         {
-            return IpcInvokeAsync<object>(MemberInvokingType.SetProperty, propertyName, new Garm<object?>[] { CastArg(value) }, namedValues);
+            return IpcInvokeAsync<object>(MemberInvokingType.SetProperty, memberId, propertyName, new Garm<object?>[] { CastArg(value) }, namedValues);
         }
 
         /// <summary>
@@ -128,9 +128,9 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
         /// <param name="namedValues">包含方法上标记的调用此 IPC 方法的个性化方式。</param>
         /// <param name="methodName">方法名。</param>
         /// <returns>可异步等待方法返回值的可等待对象。</returns>
-        protected Task CallMethod(Garm<object?>[]? args, IpcProxyMemberNamedValues namedValues, [CallerMemberName] string methodName = "")
+        protected Task CallMethod(string memberId, Garm<object?>[]? args, IpcProxyMemberNamedValues namedValues, [CallerMemberName] string methodName = "")
         {
-            return IpcInvokeAsync<object>(MemberInvokingType.Method, methodName, args, namedValues);
+            return IpcInvokeAsync<object>(MemberInvokingType.Method, memberId, methodName, args, namedValues);
         }
 
         /// <summary>
@@ -140,9 +140,9 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
         /// <param name="namedValues">包含方法上标记的调用此 IPC 方法的个性化方式。</param>
         /// <param name="methodName">方法名。</param>
         /// <returns>可异步等待方法返回值的可等待对象。</returns>
-        protected Task<T?> CallMethod<T>(Garm<object?>[]? args, IpcProxyMemberNamedValues namedValues, [CallerMemberName] string methodName = "")
+        protected Task<T?> CallMethod<T>(string memberId, Garm<object?>[]? args, IpcProxyMemberNamedValues namedValues, [CallerMemberName] string methodName = "")
         {
-            return IpcInvokeAsync<T>(MemberInvokingType.Method, methodName, args, namedValues);
+            return IpcInvokeAsync<T>(MemberInvokingType.Method, memberId, methodName, args, namedValues);
         }
 
         /// <summary>
@@ -152,9 +152,9 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
         /// <param name="namedValues">包含方法上标记的调用此 IPC 方法的个性化方式。</param>
         /// <param name="methodName">方法名。</param>
         /// <returns>可异步等待方法返回值的可等待对象。</returns>
-        protected Task CallMethodAsync(Garm<object?>[]? args, IpcProxyMemberNamedValues namedValues, [CallerMemberName] string methodName = "")
+        protected Task CallMethodAsync(string memberId, Garm<object?>[]? args, IpcProxyMemberNamedValues namedValues, [CallerMemberName] string methodName = "")
         {
-            return IpcInvokeAsync<object>(MemberInvokingType.AsyncMethod, methodName, args, namedValues);
+            return IpcInvokeAsync<object>(MemberInvokingType.AsyncMethod, memberId, methodName, args, namedValues);
         }
 
         /// <summary>
@@ -164,9 +164,9 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
         /// <param name="namedValues">包含方法上标记的调用此 IPC 方法的个性化方式。</param>
         /// <param name="methodName">方法名。</param>
         /// <returns>可异步等待方法返回值的可等待对象。</returns>
-        protected Task<T?> CallMethodAsync<T>(Garm<object?>[]? args, IpcProxyMemberNamedValues namedValues, [CallerMemberName] string methodName = "")
+        protected Task<T?> CallMethodAsync<T>(string memberId, Garm<object?>[]? args, IpcProxyMemberNamedValues namedValues, [CallerMemberName] string methodName = "")
         {
-            return IpcInvokeAsync<T>(MemberInvokingType.AsyncMethod, methodName, args, namedValues);
+            return IpcInvokeAsync<T>(MemberInvokingType.AsyncMethod, memberId, methodName, args, namedValues);
         }
 
         /// <summary>
@@ -178,7 +178,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
         /// <param name="args">调用参数。</param>
         /// <param name="namedValues">包含属性上标记的调用此 IPC 成员的个性化方式。</param>
         /// <returns>可异步等待方法返回值的可等待对象。</returns>
-        private async Task<T?> IpcInvokeAsync<T>(MemberInvokingType callType, string memberName, Garm<object?>[]? args, IpcProxyMemberNamedValues namedValues)
+        private async Task<T?> IpcInvokeAsync<T>(MemberInvokingType callType, string memberId, string memberName, Garm<object?>[]? args, IpcProxyMemberNamedValues namedValues)
         {
             var ignoresIpcException = namedValues.IgnoresIpcException ?? RuntimeConfigs?.IgnoresIpcException ?? false;
             try
@@ -186,6 +186,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
                 return (namedValues.Timeout ?? RuntimeConfigs?.Timeout) is int timeout && timeout > 0
                     ? await InvokeWithTimeoutAsync<T>(
                         callType,
+                        memberId,
                         memberName,
                         args,
                         timeout,
@@ -193,6 +194,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
                         namedValues.DefaultReturn).ConfigureAwait(false)
                     : await Invoker.IpcInvokeAsync<T>(
                         callType,
+                        memberId,
                         memberName,
                         args).ConfigureAwait(false);
             }
@@ -222,10 +224,10 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
             }
         }
 
-        private async Task<T?> InvokeWithTimeoutAsync<T>(MemberInvokingType callType, string memberName, Garm<object?>[]? args,
+        private async Task<T?> InvokeWithTimeoutAsync<T>(MemberInvokingType callType, string memberId, string memberName, Garm<object?>[]? args,
             int millisecondsTimeout, bool ignoreException, object? defaultReturn)
         {
-            var ipcTask = Invoker.IpcInvokeAsync<T>(callType, memberName, args);
+            var ipcTask = Invoker.IpcInvokeAsync<T>(callType, memberId, memberName, args);
             var timeoutTask = Task.Delay(millisecondsTimeout);
             var task = await Task.WhenAny(ipcTask, timeoutTask).ConfigureAwait(false);
             if (task == ipcTask)

--- a/src/dotnetCampus.Ipc/CompilerServices/GeneratedProxies/GeneratedIpcProxy.cs
+++ b/src/dotnetCampus.Ipc/CompilerServices/GeneratedProxies/GeneratedIpcProxy.cs
@@ -86,7 +86,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
         /// <param name="namedValues">包含属性上标记的调用此 IPC 属性的个性化方式。</param>
         /// <param name="propertyName">属性名称。</param>
         /// <returns>可异步等待的属性的值。</returns>
-        protected async Task<T?> GetValueAsync<T>(string memberId, IpcProxyMemberNamedValues namedValues, [CallerMemberName] string propertyName = "")
+        protected async Task<T?> GetValueAsync<T>(ulong memberId, IpcProxyMemberNamedValues namedValues, [CallerMemberName] string propertyName = "")
         {
             if (namedValues.IsReadonly ?? false)
             {
@@ -116,7 +116,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
         /// <param name="namedValues">包含属性上标记的调用此 IPC 属性的个性化方式。</param>
         /// <param name="propertyName">属性名称。</param>
         /// <returns>可异步等待的属性设置。</returns>
-        protected Task SetValueAsync<T>(string memberId, Garm<T> value, IpcProxyMemberNamedValues namedValues, [CallerMemberName] string propertyName = "")
+        protected Task SetValueAsync<T>(ulong memberId, Garm<T> value, IpcProxyMemberNamedValues namedValues, [CallerMemberName] string propertyName = "")
         {
             return IpcInvokeAsync<object>(MemberInvokingType.SetProperty, memberId, propertyName, new Garm<object?>[] { CastArg(value) }, namedValues);
         }
@@ -128,7 +128,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
         /// <param name="namedValues">包含方法上标记的调用此 IPC 方法的个性化方式。</param>
         /// <param name="methodName">方法名。</param>
         /// <returns>可异步等待方法返回值的可等待对象。</returns>
-        protected Task CallMethod(string memberId, Garm<object?>[]? args, IpcProxyMemberNamedValues namedValues, [CallerMemberName] string methodName = "")
+        protected Task CallMethod(ulong memberId, Garm<object?>[]? args, IpcProxyMemberNamedValues namedValues, [CallerMemberName] string methodName = "")
         {
             return IpcInvokeAsync<object>(MemberInvokingType.Method, memberId, methodName, args, namedValues);
         }
@@ -140,7 +140,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
         /// <param name="namedValues">包含方法上标记的调用此 IPC 方法的个性化方式。</param>
         /// <param name="methodName">方法名。</param>
         /// <returns>可异步等待方法返回值的可等待对象。</returns>
-        protected Task<T?> CallMethod<T>(string memberId, Garm<object?>[]? args, IpcProxyMemberNamedValues namedValues, [CallerMemberName] string methodName = "")
+        protected Task<T?> CallMethod<T>(ulong memberId, Garm<object?>[]? args, IpcProxyMemberNamedValues namedValues, [CallerMemberName] string methodName = "")
         {
             return IpcInvokeAsync<T>(MemberInvokingType.Method, memberId, methodName, args, namedValues);
         }
@@ -152,7 +152,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
         /// <param name="namedValues">包含方法上标记的调用此 IPC 方法的个性化方式。</param>
         /// <param name="methodName">方法名。</param>
         /// <returns>可异步等待方法返回值的可等待对象。</returns>
-        protected Task CallMethodAsync(string memberId, Garm<object?>[]? args, IpcProxyMemberNamedValues namedValues, [CallerMemberName] string methodName = "")
+        protected Task CallMethodAsync(ulong memberId, Garm<object?>[]? args, IpcProxyMemberNamedValues namedValues, [CallerMemberName] string methodName = "")
         {
             return IpcInvokeAsync<object>(MemberInvokingType.AsyncMethod, memberId, methodName, args, namedValues);
         }
@@ -164,7 +164,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
         /// <param name="namedValues">包含方法上标记的调用此 IPC 方法的个性化方式。</param>
         /// <param name="methodName">方法名。</param>
         /// <returns>可异步等待方法返回值的可等待对象。</returns>
-        protected Task<T?> CallMethodAsync<T>(string memberId, Garm<object?>[]? args, IpcProxyMemberNamedValues namedValues, [CallerMemberName] string methodName = "")
+        protected Task<T?> CallMethodAsync<T>(ulong memberId, Garm<object?>[]? args, IpcProxyMemberNamedValues namedValues, [CallerMemberName] string methodName = "")
         {
             return IpcInvokeAsync<T>(MemberInvokingType.AsyncMethod, memberId, methodName, args, namedValues);
         }
@@ -178,7 +178,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
         /// <param name="args">调用参数。</param>
         /// <param name="namedValues">包含属性上标记的调用此 IPC 成员的个性化方式。</param>
         /// <returns>可异步等待方法返回值的可等待对象。</returns>
-        private async Task<T?> IpcInvokeAsync<T>(MemberInvokingType callType, string memberId, string memberName, Garm<object?>[]? args, IpcProxyMemberNamedValues namedValues)
+        private async Task<T?> IpcInvokeAsync<T>(MemberInvokingType callType, ulong memberId, string memberName, Garm<object?>[]? args, IpcProxyMemberNamedValues namedValues)
         {
             var ignoresIpcException = namedValues.IgnoresIpcException ?? RuntimeConfigs?.IgnoresIpcException ?? false;
             try
@@ -224,7 +224,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
             }
         }
 
-        private async Task<T?> InvokeWithTimeoutAsync<T>(MemberInvokingType callType, string memberId, string memberName, Garm<object?>[]? args,
+        private async Task<T?> InvokeWithTimeoutAsync<T>(MemberInvokingType callType, ulong memberId, string memberName, Garm<object?>[]? args,
             int millisecondsTimeout, bool ignoreException, object? defaultReturn)
         {
             var ipcTask = Invoker.IpcInvokeAsync<T>(callType, memberId, memberName, args);

--- a/src/dotnetCampus.Ipc/CompilerServices/GeneratedProxies/Models/GeneratedProxyMemberInvokeModel.cs
+++ b/src/dotnetCampus.Ipc/CompilerServices/GeneratedProxies/Models/GeneratedProxyMemberInvokeModel.cs
@@ -42,7 +42,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
         /// 调用的成员 Id（由源代码生成器自动生成，唯一表示一个属性或方法）。
         /// </summary>
         [DataMember(Name = "d")]
-        public string? MemberId { get; internal set; }
+        public ulong MemberId { get; internal set; }
 
         /// <summary>
         /// 调用的成员名称（属性名、方法名）。

--- a/src/dotnetCampus.Ipc/CompilerServices/GeneratedProxies/Models/GeneratedProxyMemberInvokeModel.cs
+++ b/src/dotnetCampus.Ipc/CompilerServices/GeneratedProxies/Models/GeneratedProxyMemberInvokeModel.cs
@@ -39,6 +39,12 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
         public string? ContractFullTypeName { get; set; }
 
         /// <summary>
+        /// 调用的成员 Id（由源代码生成器自动生成，唯一表示一个属性或方法）。
+        /// </summary>
+        [DataMember(Name = "d")]
+        public string? MemberId { get; internal set; }
+
+        /// <summary>
         /// 调用的成员名称（属性名、方法名）。
         /// </summary>
         [DataMember(Name = "m")]

--- a/src/dotnetCampus.Ipc/CompilerServices/GeneratedProxies/PublicIpcJointManager.cs
+++ b/src/dotnetCampus.Ipc/CompilerServices/GeneratedProxies/PublicIpcJointManager.cs
@@ -134,7 +134,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
             try
             {
                 var args = ExtractArgsFromArgsModel(requestModel.Args, peer);
-                var returnValue = await InvokeMember(joint, requestModel.CallType, requestModel.MemberName!, args).ConfigureAwait(false);
+                var returnValue = await InvokeMember(joint, requestModel.CallType, requestModel.MemberId!, requestModel.MemberName!, args).ConfigureAwait(false);
                 @return = CreateReturnModelFromReturnObject(returnValue);
 #if DEBUG
                 @return.Invoking = requestModel;
@@ -207,14 +207,14 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
             }
         }
 
-        private static async Task<Garm<object?>> InvokeMember(GeneratedIpcJoint joint, MemberInvokingType callType, string memberName, object?[]? args)
+        private static async Task<Garm<object?>> InvokeMember(GeneratedIpcJoint joint, MemberInvokingType callType, string memberId, string memberName, object?[]? args)
         {
             return callType switch
             {
-                MemberInvokingType.GetProperty => joint.GetProperty(memberName),
-                MemberInvokingType.SetProperty => joint.SetProperty(memberName, args?.FirstOrDefault()),
-                MemberInvokingType.Method => joint.CallMethod(memberName, args),
-                MemberInvokingType.AsyncMethod => await joint.CallMethodAsync(memberName, args).ConfigureAwait(false),
+                MemberInvokingType.GetProperty => joint.GetProperty(memberId, memberName),
+                MemberInvokingType.SetProperty => joint.SetProperty(memberId, memberName, args?.FirstOrDefault()),
+                MemberInvokingType.Method => joint.CallMethod(memberId, memberName, args),
+                MemberInvokingType.AsyncMethod => await joint.CallMethodAsync(memberId, memberName, args).ConfigureAwait(false),
                 _ => new Garm<object?>(null),
             };
         }

--- a/src/dotnetCampus.Ipc/CompilerServices/GeneratedProxies/PublicIpcJointManager.cs
+++ b/src/dotnetCampus.Ipc/CompilerServices/GeneratedProxies/PublicIpcJointManager.cs
@@ -207,7 +207,7 @@ namespace dotnetCampus.Ipc.CompilerServices.GeneratedProxies
             }
         }
 
-        private static async Task<Garm<object?>> InvokeMember(GeneratedIpcJoint joint, MemberInvokingType callType, string memberId, string memberName, object?[]? args)
+        private static async Task<Garm<object?>> InvokeMember(GeneratedIpcJoint joint, MemberInvokingType callType, ulong memberId, string memberName, object?[]? args)
         {
             return callType switch
             {

--- a/src/dotnetCampus.Ipc/CompilerServices/GeneratedProxies/Utils/IpcProxyInvokingHelper.cs
+++ b/src/dotnetCampus.Ipc/CompilerServices/GeneratedProxies/Utils/IpcProxyInvokingHelper.cs
@@ -44,7 +44,7 @@ internal class IpcProxyInvokingHelper
     /// </summary>
     internal string? ObjectId { get; set; }
 
-    internal async Task<T?> IpcInvokeAsync<T>(MemberInvokingType callType, string memberId, string memberName, Garm<object?>[]? args)
+    internal async Task<T?> IpcInvokeAsync<T>(MemberInvokingType callType, ulong memberId, string memberName, Garm<object?>[]? args)
     {
         if (PeerProxy is null)
         {

--- a/src/dotnetCampus.Ipc/CompilerServices/GeneratedProxies/Utils/IpcProxyInvokingHelper.cs
+++ b/src/dotnetCampus.Ipc/CompilerServices/GeneratedProxies/Utils/IpcProxyInvokingHelper.cs
@@ -44,7 +44,7 @@ internal class IpcProxyInvokingHelper
     /// </summary>
     internal string? ObjectId { get; set; }
 
-    internal async Task<T?> IpcInvokeAsync<T>(MemberInvokingType callType, string memberName, Garm<object?>[]? args)
+    internal async Task<T?> IpcInvokeAsync<T>(MemberInvokingType callType, string memberId, string memberName, Garm<object?>[]? args)
     {
         if (PeerProxy is null)
         {
@@ -56,6 +56,7 @@ internal class IpcProxyInvokingHelper
             Id = ObjectId,
             ContractFullTypeName = TypeName,
             CallType = callType,
+            MemberId = memberId,
             MemberName = memberName,
             Args = args?.Select(SerializeArg).ToArray(),
         }).ConfigureAwait(false);

--- a/src/dotnetCampus.Ipc/dotnetCampus.Ipc.csproj
+++ b/src/dotnetCampus.Ipc/dotnetCampus.Ipc.csproj
@@ -39,9 +39,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Walterlv.NullableAttributes.Source" Version="7.1.0" PrivateAssets="all" />
-    <PackageReference Include="dotnetCampus.AsyncWorkerCollection.Source" Version="1.6.5" PrivateAssets="all" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Walterlv.NullableAttributes.Source" Version="7.4.0" PrivateAssets="all" />
+    <PackageReference Include="dotnetCampus.AsyncWorkerCollection.Source" Version="1.7.0" PrivateAssets="all" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>

--- a/tests/dotnetCampus.Ipc.Analyzers.Tests/dotnetCampus.Ipc.Analyzers.Tests.csproj
+++ b/tests/dotnetCampus.Ipc.Analyzers.Tests/dotnetCampus.Ipc.Analyzers.Tests.csproj
@@ -6,19 +6,22 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.0.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.MSTest" Version="1.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.MSTest" Version="1.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.MSTest" Version="1.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.MSTest" Version="1.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing.MSTest" Version="1.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
-    <PackageReference Include="coverlet.collector" Version="1.3.0" />
-    <PackageReference Include="Moq" Version="4.14.6" />
-    <PackageReference Include="MSTestEnhancer" Version="2.0.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.MSTest" Version="1.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.MSTest" Version="1.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.MSTest" Version="1.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.MSTest" Version="1.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing.MSTest" Version="1.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="MSTestEnhancer" Version="2.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/dotnetCampus.Ipc.Tests/CompilerServices/Fake/FakeIpcObject.cs
+++ b/tests/dotnetCampus.Ipc.Tests/CompilerServices/Fake/FakeIpcObject.cs
@@ -178,7 +178,7 @@ namespace dotnetCampus.Ipc.Tests.CompilerServices
 
         public long MethodWithSameParameterCountOverloading(long a, long b)
         {
-            return a + b;
+            return a * b;
         }
 
         public IFakeIpcObject.NestedEnum MethodWithNestedEnumReturn()

--- a/tests/dotnetCampus.Ipc.Tests/CompilerServices/Fake/FakeIpcObject.cs
+++ b/tests/dotnetCampus.Ipc.Tests/CompilerServices/Fake/FakeIpcObject.cs
@@ -171,6 +171,16 @@ namespace dotnetCampus.Ipc.Tests.CompilerServices
             return IpcReadonlyProperty;
         }
 
+        public int MethodWithSameParameterCountOverloading(int a, int b)
+        {
+            return a + b;
+        }
+
+        public long MethodWithSameParameterCountOverloading(long a, long b)
+        {
+            return a + b;
+        }
+
         public IFakeIpcObject.NestedEnum MethodWithNestedEnumReturn()
         {
             return IFakeIpcObject.NestedEnum.None;
@@ -181,9 +191,9 @@ namespace dotnetCampus.Ipc.Tests.CompilerServices
             return Task.FromResult(IFakeIpcObject.NestedEnum.None);
         }
 
-        public Task AsyncMethod()
+        public async Task AsyncMethod()
         {
-            return Task.CompletedTask;
+            await Task.Delay(2000);
         }
 
         public async Task<INestedFakeIpcArgumentOrReturn> AsyncMethodWithIpcPublicObjectParametersAndIpcPublicObjectReturn(INestedFakeIpcArgumentOrReturn nested, string changeValue)

--- a/tests/dotnetCampus.Ipc.Tests/CompilerServices/Fake/IFakeIpcObject.cs
+++ b/tests/dotnetCampus.Ipc.Tests/CompilerServices/Fake/IFakeIpcObject.cs
@@ -79,6 +79,10 @@ namespace dotnetCampus.Ipc.Tests.CompilerServices
 
         bool MethodWithStructReturn();
 
+        int MethodWithSameParameterCountOverloading(int a, int b);
+
+        long MethodWithSameParameterCountOverloading(long a, long b);
+
         NestedEnum MethodWithNestedEnumReturn();
 
         Task<IFakeIpcObject.NestedEnum> AsyncMethodWithNestedEnumReturn();

--- a/tests/dotnetCampus.Ipc.Tests/CompilerServices/GeneratedProxies/IpcObjectTests.cs
+++ b/tests/dotnetCampus.Ipc.Tests/CompilerServices/GeneratedProxies/IpcObjectTests.cs
@@ -238,6 +238,18 @@ namespace dotnetCampus.Ipc.Tests.CompilerServices.GeneratedProxies
                 Assert.AreEqual(new ValueTuple<double, uint, int, byte>(1, 2, 3, 4), result);
             });
 
+            "IPC 代理生成：同数量的参数。".Test(async () =>
+            {
+                // 准备。
+                var (peer, proxy) = await CreateIpcPairAsync(nameof(FakeIpcObject.AsyncMethodWithStructParametersAndStructReturn));
+
+                // 安放。
+                var result = await proxy.AsyncMethodWithStructParametersAndStructReturn(1, 2, 3, 4);
+
+                // 植物。
+                Assert.AreEqual(new ValueTuple<double, uint, int, byte>(1, 2, 3, 4), result);
+            });
+
             "IPC 代理生成：复杂参数和异步复杂返回值".Test(async () =>
             {
                 // 准备。

--- a/tests/dotnetCampus.Ipc.Tests/CompilerServices/GeneratedProxies/IpcObjectTests.cs
+++ b/tests/dotnetCampus.Ipc.Tests/CompilerServices/GeneratedProxies/IpcObjectTests.cs
@@ -217,6 +217,20 @@ namespace dotnetCampus.Ipc.Tests.CompilerServices.GeneratedProxies
                 Assert.AreEqual(true, result);
             });
 
+            "IPC 代理生成：同数量的参数组成的重载方法组。".Test(async () =>
+            {
+                // 准备。
+                var (peer, proxy) = await CreateIpcPairAsync(nameof(FakeIpcObject.MethodWithSameParameterCountOverloading));
+
+                // 安放。
+                var int32Result = proxy.MethodWithSameParameterCountOverloading(1, 2);
+                var int64Result = proxy.MethodWithSameParameterCountOverloading(1l, 2l);
+
+                // 植物。
+                Assert.AreEqual(3, int32Result);
+                Assert.AreEqual(2l, int64Result);
+            });
+
             "IPC 代理生成：异步返回值".Test(async () =>
             {
                 // 准备。
@@ -227,18 +241,6 @@ namespace dotnetCampus.Ipc.Tests.CompilerServices.GeneratedProxies
             });
 
             "IPC 代理生成：多参数和异步结构体返回值。".Test(async () =>
-            {
-                // 准备。
-                var (peer, proxy) = await CreateIpcPairAsync(nameof(FakeIpcObject.AsyncMethodWithStructParametersAndStructReturn));
-
-                // 安放。
-                var result = await proxy.AsyncMethodWithStructParametersAndStructReturn(1, 2, 3, 4);
-
-                // 植物。
-                Assert.AreEqual(new ValueTuple<double, uint, int, byte>(1, 2, 3, 4), result);
-            });
-
-            "IPC 代理生成：同数量的参数。".Test(async () =>
             {
                 // 准备。
                 var (peer, proxy) = await CreateIpcPairAsync(nameof(FakeIpcObject.AsyncMethodWithStructParametersAndStructReturn));

--- a/tests/dotnetCampus.Ipc.Tests/CompilerServices/GeneratedProxies/NotGeneratedTestOnlyFakeIpcObjectIpcShape.cs
+++ b/tests/dotnetCampus.Ipc.Tests/CompilerServices/GeneratedProxies/NotGeneratedTestOnlyFakeIpcObjectIpcShape.cs
@@ -148,6 +148,16 @@ namespace dotnetCampus.Ipc.Tests.CompilerServices.GeneratedProxies
             throw null;
         }
 
+        public int MethodWithSameParameterCountOverloading(int a, int b)
+        {
+            throw null;
+        }
+
+        public long MethodWithSameParameterCountOverloading(long a, long b)
+        {
+            throw null;
+        }
+
         [IpcMethod]
         IFakeIpcObject.NestedEnum IFakeIpcObject.MethodWithNestedEnumReturn()
         {

--- a/tests/dotnetCampus.Ipc.Tests/dotnetCampus.Ipc.Tests.csproj
+++ b/tests/dotnetCampus.Ipc.Tests/dotnetCampus.Ipc.Tests.csproj
@@ -7,15 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="MSTestEnhancer" Version="2.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
+    <PackageReference Include="coverlet.collector" Version="1.3.0" />
+    <PackageReference Include="Moq" Version="4.14.6" />
+    <PackageReference Include="MSTestEnhancer" Version="2.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/dotnetCampus.Ipc.Tests/dotnetCampus.Ipc.Tests.csproj
+++ b/tests/dotnetCampus.Ipc.Tests/dotnetCampus.Ipc.Tests.csproj
@@ -7,12 +7,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
-    <PackageReference Include="coverlet.collector" Version="1.3.0" />
-    <PackageReference Include="Moq" Version="4.14.6" />
-    <PackageReference Include="MSTestEnhancer" Version="2.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="MSTestEnhancer" Version="2.2.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
更新内容：

* Ipc 接口中现在支持参数相同的重载方法了（之前是通过成员名称和参数数量来决定调用哪个方法的，所以名称相同且参数个数相同时无法区分重载，见 #116 ）
* 使用 IIncrementalGenerator 替代 ISourceGenerator，以支持增量生成源代码

解决问题：

* @afunc233 Fix: #116 
* @sharwell Fix: #97 