### PR TITLE
使 IPC 对象支持传输集合接口类型

### DIFF
--- a/src/dotnetCampus.Ipc.Analyzers/CodeAnalysis/Utils/IpcSemanticAttributeHelper.cs
+++ b/src/dotnetCampus.Ipc.Analyzers/CodeAnalysis/Utils/IpcSemanticAttributeHelper.cs
@@ -8,6 +8,17 @@ namespace dotnetCampus.Ipc.CodeAnalysis.Utils;
 internal static class IpcSemanticAttributeHelper
 {
     /// <summary>
+    /// 如果类型是 IPC 类型，则返回 true；否则返回 false。
+    /// <para>IPC 类型为标记了 <see cref="IpcPublicAttribute"/> 或 <see cref="IpcShapeAttribute"/> 的类型。</para>
+    /// </summary>
+    /// <param name="type">要检查的类型。</param>
+    /// <returns></returns>
+    internal static bool GetIsIpcType(this ITypeSymbol type)
+    {
+        return type.GetIsDefined<IpcPublicAttribute>() || type.GetIsDefined<IpcShapeAttribute>();
+    }
+
+    /// <summary>
     /// 检查此类型上标记的 <see cref="IpcPublicAttribute"/> 并将其转换为传入 IPC 代理的类型。
     /// </summary>
     /// <param name="type"></param>

--- a/src/dotnetCampus.Ipc.Analyzers/CodeAnalysis/Utils/SemanticAttributeHelper.cs
+++ b/src/dotnetCampus.Ipc.Analyzers/CodeAnalysis/Utils/SemanticAttributeHelper.cs
@@ -54,6 +54,20 @@ internal static class SemanticAttributeHelper
     }
 
     /// <summary>
+    /// 检查此成员是否已定义了 <typeparamref name="TAttribute"/> 类型的特性。
+    /// </summary>
+    /// <typeparam name="TAttribute">要检查的类型。</typeparam>
+    /// <param name="symbol">要查找特性的语义符号。</param>
+    /// <returns>如果定义了 <typeparamref name="TAttribute"/>，则返回 true；否则返回 false。</returns>
+    internal static bool GetIsDefined<TAttribute>(this ISymbol symbol)
+    {
+        return symbol.GetAttributes().FirstOrDefault(x => string.Equals(
+            x.AttributeClass?.ToString(),
+            typeof(TAttribute).FullName,
+            StringComparison.Ordinal)) is { } ipcMethodAttribute;
+    }
+
+    /// <summary>
     /// 检查此成员的 <paramref name="attributeTypeName"/> 类型特性的 <paramref name="namedArgumentName"/> 名字的参数的值。
     /// </summary>
     /// <param name="symbol">要查找特性的语义符号。</param>

--- a/src/dotnetCampus.Ipc.Analyzers/SourceGenerators/Compiling/Members/IpcPublicMethodInfo.cs
+++ b/src/dotnetCampus.Ipc.Analyzers/SourceGenerators/Compiling/Members/IpcPublicMethodInfo.cs
@@ -247,9 +247,9 @@ void {methodContainingTypeName}.{_contractMethod.Name}({parameters})
     {
         return string.Join(
             ", ",
-            parameters.Select(x => x.Type.TypeKind == TypeKind.Interface
+            parameters.Select(x => x.Type.GetIsIpcType()
                 ? $"new Garm<{builder.SimplifyNameByAddUsing(x.Type)}>({x.Name}, typeof({x.Type.Name}))"
-                : $"{x.Name}"));
+                : $"new Garm<{builder.SimplifyNameByAddUsing(x.Type)}>({x.Name})"));
     }
 
     /// <summary>
@@ -296,7 +296,7 @@ void {methodContainingTypeName}.{_contractMethod.Name}({parameters})
     /// <returns>方法实参列表字符串。</returns>
     private string GenerateGarmReturn(SourceTextBuilder builder, ITypeSymbol @return, string value)
     {
-        return @return.TypeKind == TypeKind.Interface
+        return @return.GetIsIpcType()
                 ? $"new Garm<{builder.SimplifyNameByAddUsing(@return)}>({value}, typeof({@return.Name}))"
                 : $"new Garm<{builder.SimplifyNameByAddUsing(@return)}>({value})";
     }

--- a/src/dotnetCampus.Ipc.Analyzers/SourceGenerators/Compiling/Members/IpcPublicPropertyInfo.cs
+++ b/src/dotnetCampus.Ipc.Analyzers/SourceGenerators/Compiling/Members/IpcPublicPropertyInfo.cs
@@ -162,8 +162,8 @@ internal class IpcPublicPropertyInfo : IPublicIpcObjectProxyMemberGenerator, IPu
     /// <returns></returns>
     private string GenerateGarmArgument(SourceTextBuilder builder, ITypeSymbol parameterType, string argumentName)
     {
-        return parameterType.TypeKind == TypeKind.Interface
+        return parameterType.GetIsIpcType()
                 ? $"new Garm<{builder.SimplifyNameByAddUsing(parameterType)}>({argumentName}, typeof({parameterType.Name}))"
-                : argumentName;
+                : $"new Garm<{builder.SimplifyNameByAddUsing(parameterType)}>({argumentName})";
     }
 }

--- a/tests/dotnetCampus.Ipc.Tests/CompilerServices/Fake/FakeIpcObject.cs
+++ b/tests/dotnetCampus.Ipc.Tests/CompilerServices/Fake/FakeIpcObject.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -55,6 +57,12 @@ namespace dotnetCampus.Ipc.Tests.CompilerServices
             get => _nestedIpcObject;
             set => _nestedIpcObject = value;
         }
+
+        public List<string>? ListProperty { get; set; } = new List<string>() { "List1", "List2" };
+
+        public IList<string>? CollectionProperty { get; set; } = new List<string>() { "Collection1", "Collection2" };
+
+        public string[]? ArrayProperty { get; set; } = new string[] { "Array1", "Array2" };
 
         public void WaitsVoidMethod()
         {
@@ -134,6 +142,24 @@ namespace dotnetCampus.Ipc.Tests.CompilerServices
         {
             await Task.Delay(150);
             return "xxx";
+        }
+
+        public async Task<List<string>> MethodWithListParametersAndListReturn(List<string> a, List<string> b)
+        {
+            await Task.Delay(1);
+            return a.Concat(b).ToList();
+        }
+
+        public async Task<IList<string>> MethodWithCollectionParametersAndCollectionReturn(IList<string> a, IList<string> b)
+        {
+            await Task.Delay(1);
+            return a.Concat(b).ToList();
+        }
+
+        public async Task<string[]> MethodWithArrayParametersAndArrayReturn(string[] a, string[] b)
+        {
+            await Task.Delay(1);
+            return a.Concat(b).ToArray();
         }
 
         public void MethodWithStructParameters(BindingFlags flags)

--- a/tests/dotnetCampus.Ipc.Tests/CompilerServices/Fake/IFakeIpcObject.cs
+++ b/tests/dotnetCampus.Ipc.Tests/CompilerServices/Fake/IFakeIpcObject.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Reflection;
 using System.Threading.Tasks;
 
@@ -18,6 +19,12 @@ namespace dotnetCampus.Ipc.Tests.CompilerServices
         IntPtr IntPtrProperty { get; }
 
         IntPtr? NullableIntPtrProperty { get; }
+
+        List<string>? ListProperty { get; set; }
+
+        IList<string>? CollectionProperty { get; set; }
+
+        string[]? ArrayProperty { get; set; }
 
         INestedFakeIpcArgumentOrReturn NestedIpcProperty { get; set; }
 
@@ -61,6 +68,12 @@ namespace dotnetCampus.Ipc.Tests.CompilerServices
 
         [IpcMethod(DefaultReturn = "default1")]
         Task<string> MethodThatCannotBeCompiled_MustSetOtherAttributes();
+
+        Task<List<string>> MethodWithListParametersAndListReturn(List<string> a, List<string> b);
+
+        Task<IList<string>> MethodWithCollectionParametersAndCollectionReturn(IList<string> a, IList<string> b);
+
+        Task<string[]> MethodWithArrayParametersAndArrayReturn(string[] a, string[] b);
 
         void MethodWithStructParameters(BindingFlags flags);
 

--- a/tests/dotnetCampus.Ipc.Tests/CompilerServices/GeneratedProxies/IpcObjectTests.cs
+++ b/tests/dotnetCampus.Ipc.Tests/CompilerServices/GeneratedProxies/IpcObjectTests.cs
@@ -1,5 +1,7 @@
 ﻿#nullable enable
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using System.Threading;
@@ -13,6 +15,7 @@ using dotnetCampus.Ipc.Tests.CompilerServices.Fake;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+using MSTest.Extensions.AssertExtensions;
 using MSTest.Extensions.Contracts;
 
 namespace dotnetCampus.Ipc.Tests.CompilerServices.GeneratedProxies
@@ -288,6 +291,88 @@ namespace dotnetCampus.Ipc.Tests.CompilerServices.GeneratedProxies
                 // 对接端的值被代理端修改。
                 Assert.AreEqual("test changed from proxy side", jointSideObject.Value);
                 Assert.AreEqual("test changed from proxy side", result.Value);
+            });
+        }
+
+        [ContractTestCase]
+        public void IpcCollectionTests()
+        {
+            "IPC 代理生成：集合（列表）属性".Test(async () =>
+            {
+                // 准备。
+                var (peer, proxy) = await CreateIpcPairAsync(nameof(FakeIpcObject.ListProperty));
+
+                // 安放。
+                var result = proxy.ListProperty;
+
+                // 植物。
+                CollectionAssert.AreEqual(new string[] { "List1", "List2" }, result);
+            });
+
+            "IPC 代理生成：集合（接口）属性".Test(async () =>
+            {
+                // 准备。
+                var (peer, proxy) = await CreateIpcPairAsync(nameof(FakeIpcObject.CollectionProperty));
+
+                // 安放。
+                var result = proxy.CollectionProperty;
+
+                // 植物。
+                CollectionAssert.AreEqual(new string[] { "Collection1", "Collection2" }, (ICollection?) result);
+            });
+
+            "IPC 代理生成：集合（数组）属性".Test(async () =>
+            {
+                // 准备。
+                var (peer, proxy) = await CreateIpcPairAsync(nameof(FakeIpcObject.ArrayProperty));
+
+                // 安放。
+                var result = proxy.ArrayProperty;
+
+                // 植物。
+                CollectionAssert.AreEqual(new string[] { "Array1", "Array2" }, result);
+            });
+
+            "IPC 代理生成：集合（列表）异步方法".Test(async () =>
+            {
+                // 准备。
+                var (peer, proxy) = await CreateIpcPairAsync(nameof(FakeIpcObject.MethodWithListParametersAndListReturn));
+
+                // 安放。
+                var result = await proxy.MethodWithListParametersAndListReturn(
+                    new List<string> { "a", "b" },
+                    new List<string> { "c", "d" });
+
+                // 植物。
+                CollectionAssert.AreEqual(new string[] { "a", "b", "c", "d" }, result);
+            });
+
+            "IPC 代理生成：集合（接口）异步方法".Test(async () =>
+            {
+                // 准备。
+                var (peer, proxy) = await CreateIpcPairAsync(nameof(FakeIpcObject.MethodWithCollectionParametersAndCollectionReturn));
+
+                // 安放。
+                var result = await proxy.MethodWithCollectionParametersAndCollectionReturn(
+                    new List<string> { "a", "b" },
+                    new List<string> { "c", "d" });
+
+                // 植物。
+                CollectionAssert.AreEqual(new string[] { "a", "b", "c", "d" }, (ICollection) result);
+            });
+
+            "IPC 代理生成：集合（数组）异步方法".Test(async () =>
+            {
+                // 准备。
+                var (peer, proxy) = await CreateIpcPairAsync(nameof(FakeIpcObject.MethodWithArrayParametersAndArrayReturn));
+
+                // 安放。
+                var result = await proxy.MethodWithArrayParametersAndArrayReturn(
+                    new string[] { "a", "b" },
+                    new string[] { "c", "d" });
+
+                // 植物。
+                CollectionAssert.AreEqual(new string[] { "a", "b", "c", "d" }, result);
             });
         }
 

--- a/tests/dotnetCampus.Ipc.Tests/CompilerServices/GeneratedProxies/NotGeneratedTestOnlyFakeIpcObjectIpcShape.cs
+++ b/tests/dotnetCampus.Ipc.Tests/CompilerServices/GeneratedProxies/NotGeneratedTestOnlyFakeIpcObjectIpcShape.cs
@@ -3,6 +3,8 @@ using dotnetCampus.Ipc.CompilerServices.GeneratedProxies;
 using dotnetCampus.Ipc.Tests.CompilerServices;
 using dotnetCampus.Ipc.Tests.CompilerServices.Fake;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 
@@ -31,6 +33,15 @@ namespace dotnetCampus.Ipc.Tests.CompilerServices.GeneratedProxies
 
         [IpcProperty]
         INestedFakeIpcArgumentOrReturn IFakeIpcObject.NestedIpcProperty { get; set; }
+
+        [IpcProperty]
+        public List<string> ListProperty { get; set; }
+
+        [IpcProperty]
+        public IList<string> CollectionProperty { get; set; }
+
+        [IpcProperty]
+        public string[] ArrayProperty { get; set; }
 
         [IpcMethod]
         void IFakeIpcObject.WaitsVoidMethod()
@@ -106,6 +117,21 @@ namespace dotnetCampus.Ipc.Tests.CompilerServices.GeneratedProxies
 
         [IpcMethod]
         Task<string> IFakeIpcObject.MethodThatCannotBeCompiled_MustSetOtherAttributes()
+        {
+            throw null;
+        }
+
+        public Task<List<string>> MethodWithListParametersAndListReturn(List<string> a, List<string> b)
+        {
+            throw null;
+        }
+
+        public Task<IList<string>> MethodWithCollectionParametersAndCollectionReturn(IList<string> a, IList<string> b)
+        {
+            throw null;
+        }
+
+        public Task<string[]> MethodWithArrayParametersAndArrayReturn(string[] a, string[] b)
         {
             throw null;
         }


### PR DESCRIPTION
本申请是对 #119 的补充，补充以下内容：

* 对 IPC 对象中的数组、集合类型进行单元测试
* 使 IPC 对象支持集合接口类型，并对其进行单元测试

解决：

* Fix: #118 