### PR TITLE
抛出更加明确的异常

### DIFF
--- a/src/dotnetCampus.Ipc/Exceptions/IpcPipeConnectionException.cs
+++ b/src/dotnetCampus.Ipc/Exceptions/IpcPipeConnectionException.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace dotnetCampus.Ipc.Exceptions
+{
+    /// <summary>
+    /// 进行管道连接时的异常
+    /// </summary>
+    public class IpcPipeConnectionException : IpcLocalException
+    {
+        internal IpcPipeConnectionException(string connectingPipeName, string localClientName, string remoteServerName, string message, Exception innerException) : base(message, innerException)
+        {
+            ConnectingPipeName = connectingPipeName;
+            LocalPeerName = localClientName;
+            RemotePeerName = remoteServerName;
+        }
+
+        /// <summary>
+        /// 正在连接中的管道名。按照当前的设计，应该和 <see cref="RemotePeerName"/> 是相同的值
+        /// </summary>
+        public string ConnectingPipeName { get; }
+
+        /// <summary>
+        /// 本地当前的 Peer 名
+        /// </summary>
+        public string LocalPeerName { get; }
+
+        /// <summary>
+        /// 远端对方的 Peer 名
+        /// </summary>
+        public string RemotePeerName { get; }
+    }
+}

--- a/src/dotnetCampus.Ipc/Pipes/IpcClientService.cs
+++ b/src/dotnetCampus.Ipc/Pipes/IpcClientService.cs
@@ -210,10 +210,23 @@ namespace dotnetCampus.Ipc.Pipes
 
             void ConnectNamedPipe()
             {
-                namedPipeClientStream.Connect();
+                try
+                {
+                    namedPipeClientStream.Connect();
 
-                // 强行捕获变量，方便调试是在等待哪个连接
-                Logger.Trace($"Connected NamedPipe by {nameof(DefaultConnectNamedPipeAsync)}. LocalClient:'{localClient}';RemoteServer:'{remoteServer}'");
+                    // 强行捕获变量，方便调试是在等待哪个连接
+                    Logger.Trace($"Connected NamedPipe by {nameof(DefaultConnectNamedPipeAsync)}. LocalClient:'{localClient}';RemoteServer:'{remoteServer}'");
+                }
+                catch (Exception e)
+                {
+                    // 管道连接失败了，比如抛出的是 UnauthorizedAccessException 异常
+                    var message =
+                        $"IPC Pipe connect to `{remoteServer}` exception by {nameof(DefaultConnectNamedPipeAsync)}. LocalClient:`{localClient}`;RemoteServer:`{remoteServer}`. Exception:{e.Message}";
+
+                    Logger.Trace(message);
+
+                    throw new IpcPipeConnectionException(remoteServer, localClient, remoteServer, message, e);
+                }
             }
         }
 


### PR DESCRIPTION
以下是收到的埋点信息，不知道是哪个炸了

```
Name: System.UnauthorizedAccessException;
Message: Access to the path is denied.;
StackTrace:    at System.IO.Pipes.NamedPipeClientStream.TryConnect(Int32 timeout, CancellationToken cancellationToken)
   at System.IO.Pipes.NamedPipeClientStream.ConnectInternal(Int32 timeout, CancellationToken cancellationToken, Int32 startTime)
   at System.IO.Pipes.NamedPipeClientStream.Connect(Int32 timeout)
   at System.IO.Pipes.NamedPipeClientStream.Connect()
   at dotnetCampus.Ipc.Pipes.IpcClientService.<>c__DisplayClass22_0.<DefaultConnectNamedPipeAsync>g__ConnectNamedPipe|0()
   at System.Threading.Tasks.Task.InnerInvoke()
   at System.Threading.Tasks.Task.<>c.<.cctor>b__272_0(Object obj)
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
--- End of stack trace from previous location ---
   at dotnetCampus.Ipc.Pipes.IpcClientService.DefaultConnectNamedPipeAsync(NamedPipeClientStream namedPipeClientStream)
   at dotnetCampus.Ipc.Pipes.IpcClientService.ConnectNamedPipeAsync(NamedPipeClientStream namedPipeClientStream)
   at dotnetCampus.Ipc.Pipes.IpcClientService.Start(Boolean shouldRegisterToPeer)
   at dotnetCampus.Ipc.Pipes.IpcProvider.ConnectBackToPeer(IpcInternalPeerConnectedArgs e)
   at dotnetCampus.Ipc.Pipes.IpcProvider.NamedPipeServerStreamPoolPeerConnected(Object sender, IpcInternalPeerConnectedArgs e)
   at System.Threading.Tasks.Task.<>c.<ThrowAsync>b__128_1(Object state)
   at System.Threading.QueueUserWorkItemCallbackDefaultContext.Execute()
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart()
   at System.Threading.Thread.StartCallback();
```