### PR TITLE
修改 IPC 的日志模块，让其在业务端有更加正确的输出

### DIFF
--- a/src/dotnetCampus.Ipc/Utils/Extensions/LoggerExtensions.cs
+++ b/src/dotnetCampus.Ipc/Utils/Extensions/LoggerExtensions.cs
@@ -8,17 +8,17 @@ namespace dotnetCampus.Ipc.Utils.Extensions
     {
         public static void Trace(this ILogger? logger, string message)
         {
-            logger?.Log(LogLevel.Trace, default, 0, null, (s, e) => message);
+            logger?.Log(LogLevel.Trace, default, message, null, FormatOnlyMessage);
         }
 
         public static void Debug(this ILogger? logger, string message)
         {
-            logger?.Log(LogLevel.Debug, default, 0, null, (s, e) => message);
+            logger?.Log(LogLevel.Debug, default, message, null, FormatOnlyMessage);
         }
 
         public static void Information(this ILogger? logger, string message)
         {
-            logger?.Log(LogLevel.Information, default, 0, null, (s, e) => message);
+            logger?.Log(LogLevel.Information, default, message, null, FormatOnlyMessage);
         }
 
         public static void Warning(this ILogger? logger, string message)
@@ -29,7 +29,7 @@ namespace dotnetCampus.Ipc.Utils.Extensions
             }
             else
             {
-                logger?.Log(LogLevel.Warning, default, 0, null, (s, e) => message);
+                logger?.Log(LogLevel.Warning, default, message, null, FormatOnlyMessage);
             }
         }
 
@@ -41,13 +41,24 @@ namespace dotnetCampus.Ipc.Utils.Extensions
             }
             else
             {
-                logger?.Log(LogLevel.Error, default, 0, null, (s, e) => message);
+                logger?.Log(LogLevel.Error, default, message, null, FormatOnlyMessage);
             }
         }
 
         public static void Error(this ILogger? logger, Exception exception, string? message = null)
         {
-            logger?.Log(LogLevel.Error, default, 0, exception, (s, e) => message ?? "");
+            logger?.Log(LogLevel.Error, default, message, exception, StandardFormatMessage);
         }
+
+        private static Func<string, Exception?, string> FormatOnlyMessage => static (s, _) => s;
+
+        private static Func<string?, Exception?, string> StandardFormatMessage => static (s, e) =>
+        {
+            if (s is null && e != null)
+            {
+                return e.ToString();
+            }
+            return $"[IPC Error] {s} {e}";
+        };
     }
 }


### PR DESCRIPTION
由于原本的 IPC 日志里面，没有将 exception 进行格式化输出，导致业务端收到的日志的异常信息如下

```
业务端 HandleRequestAsync 发生异常
```

也就丢失异常信息。现在修改格式化逻辑让其可以输出异常内容，附带优化一下表达式为 static 减少委托创建