### PR TITLE
处理 IPC 默认值，避免歧义

### DIFF
--- a/src/dotnetCampus.Ipc.Analyzers/CodeAnalysis/Core/Diagnostics.cs
+++ b/src/dotnetCampus.Ipc.Analyzers/CodeAnalysis/Core/Diagnostics.cs
@@ -20,7 +20,7 @@ internal static class Diagnostics
         Categories.Compiler,
         DiagnosticSeverity.Error,
         true,
-        customTags: new[] { AnalyzerException, NotConfigurable });
+        customTags: [AnalyzerException, NotConfigurable]);
 
     /// <summary>
     /// 生成代码时出现已知错误。本生成器不会报告此错误，因为后续编译器会准确报告之。
@@ -32,7 +32,7 @@ internal static class Diagnostics
         Categories.Compiler,
         DiagnosticSeverity.Hidden,
         true,
-        customTags: new[] { NotConfigurable });
+        customTags: [NotConfigurable]);
 
     /// <summary>
     /// 生成代码时出现已知错误。本生成器不会报告此错误，因为分析器会准确报告之。
@@ -44,7 +44,7 @@ internal static class Diagnostics
         Categories.Compiler,
         DiagnosticSeverity.Hidden,
         true,
-        customTags: new[] { NotConfigurable });
+        customTags: [NotConfigurable]);
 
     public static DiagnosticDescriptor IPC101_IpcType_TimeoutCannotBeNegative { get; } = new(
         nameof(IPC101),
@@ -61,7 +61,7 @@ internal static class Diagnostics
         Categories.Useless,
         DiagnosticSeverity.Hidden,
         true,
-        customTags: new[] { Unnecessary });
+        customTags: [Unnecessary]);
 
     public static DiagnosticDescriptor IPC131_IpcMembers_IgnoresIpcExceptionIsRecommended { get; } = new(
         nameof(IPC131),
@@ -78,7 +78,7 @@ internal static class Diagnostics
         Categories.Mechanism,
         DiagnosticSeverity.Error,
         true,
-        customTags: new[] { NotConfigurable });
+        customTags: [NotConfigurable]);
 
     public static DiagnosticDescriptor IPC161_IpcShape_ContractTypeDismatchWithInterface { get; } = new(
         nameof(IPC161),
@@ -87,7 +87,7 @@ internal static class Diagnostics
         Categories.Mechanism,
         DiagnosticSeverity.Error,
         true,
-        customTags: new[] { NotConfigurable });
+        customTags: [NotConfigurable]);
 
     public static DiagnosticDescriptor IPC162_IpcShape_AllMembersShouldBeMarkedAsIpcMembers { get; } = new(
         nameof(IPC162),
@@ -104,7 +104,7 @@ internal static class Diagnostics
         Categories.Mechanism,
         DiagnosticSeverity.Error,
         true,
-        customTags: new[] { NotConfigurable });
+        customTags: [NotConfigurable]);
 
     public static DiagnosticDescriptor IPC201_IpcMember_EmptyIpcMemberAttributeIsUnnecessary { get; } = new(
         nameof(IPC201),
@@ -113,7 +113,7 @@ internal static class Diagnostics
         Categories.Useless,
         DiagnosticSeverity.Hidden,
         true,
-        customTags: new[] { Unnecessary });
+        customTags: [Unnecessary]);
 
     public static DiagnosticDescriptor IPC202_IpcMember_AllMembersShouldBeMarkedAsIpcMembers { get; } = new(
         nameof(IPC202),
@@ -130,7 +130,7 @@ internal static class Diagnostics
         Categories.AvoidBugs,
         DiagnosticSeverity.Info,
         true,
-        customTags: new[] { NotConfigurable });
+        customTags: [NotConfigurable]);
 
     public static DiagnosticDescriptor IPC241_IpcProperty_SetOnlyPropertyIsNotSupported { get; } = new(
         nameof(IPC241),
@@ -139,7 +139,7 @@ internal static class Diagnostics
         Categories.Mechanism,
         DiagnosticSeverity.Error,
         true,
-        customTags: new[] { NotConfigurable });
+        customTags: [NotConfigurable]);
 
     public static DiagnosticDescriptor IPC242_IpcProperty_DefaultReturnDependsOnIgnoresIpcException { get; } = new(
         nameof(IPC242),
@@ -148,7 +148,7 @@ internal static class Diagnostics
         Categories.Useless,
         DiagnosticSeverity.Hidden,
         true,
-        customTags: new[] { Unnecessary });
+        customTags: [Unnecessary]);
 
     public static DiagnosticDescriptor IPC243_IpcProperty_IsReadonlyFalseIsUnnecessary { get; } = new(
         nameof(IPC243),
@@ -157,7 +157,7 @@ internal static class Diagnostics
         Categories.Useless,
         DiagnosticSeverity.Hidden,
         true,
-        customTags: new[] { Unnecessary });
+        customTags: [Unnecessary]);
 
     public static DiagnosticDescriptor IPC244_IpcProperty_DefaultReturnDismatchWithPropertyType { get; } = new(
         nameof(IPC244),
@@ -206,7 +206,7 @@ internal static class Diagnostics
         Categories.AvoidBugs,
         DiagnosticSeverity.Info,
         true,
-        customTags: new[] { NotConfigurable });
+        customTags: [NotConfigurable]);
 
     public static DiagnosticDescriptor IPC261_IpcMethod_DefaultReturnDependsOnIgnoresIpcException { get; } = new(
         nameof(IPC261),
@@ -215,7 +215,7 @@ internal static class Diagnostics
         Categories.Useless,
         DiagnosticSeverity.Hidden,
         true,
-        customTags: new[] { Unnecessary });
+        customTags: [Unnecessary]);
 
     public static DiagnosticDescriptor IPC262_IpcMethod_WaitsVoidIsRecommended { get; } = new(
         nameof(IPC262),
@@ -232,7 +232,7 @@ internal static class Diagnostics
         Categories.Useless,
         DiagnosticSeverity.Hidden,
         true,
-        customTags: new[] { Unnecessary });
+        customTags: [Unnecessary]);
 
     public static DiagnosticDescriptor IPC264_IpcMethod_DefaultReturnDismatchWithMethodReturnType { get; } = new(
         nameof(IPC264),
@@ -249,7 +249,7 @@ internal static class Diagnostics
         Categories.Useless,
         DiagnosticSeverity.Hidden,
         true,
-        customTags: new[] { Unnecessary });
+        customTags: [Unnecessary]);
 
     public static DiagnosticDescriptor IPC266_IpcMethod_DefaultReturnIsUselessForATaskMethod { get; } = new(
         nameof(IPC266),
@@ -258,7 +258,7 @@ internal static class Diagnostics
         Categories.Useless,
         DiagnosticSeverity.Hidden,
         true,
-        customTags: new[] { Unnecessary });
+        customTags: [Unnecessary]);
 
     public static DiagnosticDescriptor IPC267_IpcMethod_DefaultReturnsStringForAnObjectType { get; } = new(
         nameof(IPC267),
@@ -291,7 +291,7 @@ internal static class Diagnostics
         Categories.Mechanism,
         DiagnosticSeverity.Error,
         true,
-        customTags: new[] { NotConfigurable });
+        customTags: [NotConfigurable]);
 
     public static DiagnosticDescriptor IPC271_IpcMethod_MethodParameterTypeIsNotSupportedForIpc { get; } = new(
         nameof(IPC271),
@@ -340,7 +340,7 @@ internal static class Diagnostics
         Categories.Useless,
         DiagnosticSeverity.Hidden,
         true,
-        customTags: new[] { Unnecessary });
+        customTags: [Unnecessary]);
 
     public static DiagnosticDescriptor IPC305_CreateIpcProxy_IgnoresIpcExceptionIsRecommended { get; } = new(
         nameof(IPC305),
@@ -357,7 +357,7 @@ internal static class Diagnostics
         Categories.Useless,
         DiagnosticSeverity.Hidden,
         true,
-        customTags: new[] { Unnecessary });
+        customTags: [Unnecessary]);
 
     public static DiagnosticDescriptor IPC307_CreateIpcProxy_TimeoutIsRecommended { get; } = new(
         nameof(IPC307),
@@ -374,7 +374,7 @@ internal static class Diagnostics
         Categories.Useless,
         DiagnosticSeverity.Hidden,
         true,
-        customTags: new[] { Unnecessary });
+        customTags: [Unnecessary]);
 
     public static DiagnosticDescriptor IPC309_CreateIpcProxy_IpcShapeIsNotValid { get; } = new(
         nameof(IPC309),
@@ -383,7 +383,7 @@ internal static class Diagnostics
         Categories.Mechanism,
         DiagnosticSeverity.Error,
         true,
-        customTags: new[] { NotConfigurable });
+        customTags: [NotConfigurable]);
 
     public static DiagnosticDescriptor IPC310_CreateIpcProxy_IpcShapeDismatchWithContractType { get; } = new(
         nameof(IPC310),
@@ -392,7 +392,7 @@ internal static class Diagnostics
         Categories.Mechanism,
         DiagnosticSeverity.Error,
         true,
-        customTags: new[] { NotConfigurable });
+        customTags: [NotConfigurable]);
 
     public static DiagnosticDescriptor IPCTMP1_IpcMembers_EventIsNotSupported { get; } = new(
         "IPCTMP1",
@@ -401,7 +401,7 @@ internal static class Diagnostics
         Categories.Mechanism,
         DiagnosticSeverity.Error,
         true,
-        customTags: new[] { NotConfigurable });
+        customTags: [NotConfigurable]);
 
     private static class Categories
     {

--- a/src/dotnetCampus.Ipc.Analyzers/CodeAnalysis/Models/IpcPublicAttributeNamedValues.cs
+++ b/src/dotnetCampus.Ipc.Analyzers/CodeAnalysis/Models/IpcPublicAttributeNamedValues.cs
@@ -23,7 +23,7 @@ internal class IpcPublicAttributeNamedValues
 
     public ITypeSymbol? MemberReturnType { get; }
 
-    public Assignable<object?>? DefaultReturn { get; init; }
+    public Assignable<string?>? DefaultReturn { get; init; }
 
     public Assignable<bool>? IgnoresIpcException { get; init; }
 
@@ -40,7 +40,7 @@ internal class IpcPublicAttributeNamedValues
         var baseIndent = string.Concat(Enumerable.Repeat(indent, baseIndentLevel));
         List<string> assignments =
         [
-            Format(nameof(DefaultReturn), DefaultReturn, x => Format(x, MemberReturnType)),
+            Format(nameof(DefaultReturn), DefaultReturn, x => x ?? "null"),
             Format(nameof(Timeout), Timeout),
             Format(nameof(IgnoresIpcException), IgnoresIpcException),
             Format(nameof(IsReadonly), IsReadonly),
@@ -100,36 +100,6 @@ internal class IpcPublicAttributeNamedValues
         if (value is int int32Value)
         {
             // 可能会出现隐式转换，所以难以判断目标类型。
-            return int32Value.ToString(CultureInfo.InvariantCulture);
-        }
-        else
-        {
-            return value.ToString();
-        }
-    }
-
-    /// <summary>
-    /// 将 Attribute 里设置的值转为字符串。
-    /// </summary>
-    /// <param name="value">值。</param>
-    /// <param name="valueType">值的类型。</param>
-    /// <returns></returns>
-    protected static string Format(object? value, ITypeSymbol? valueType)
-    {
-        if (value is null)
-        {
-            return "null";
-        }
-        else if (valueType?.ToString() == "string")
-        {
-            return $@"""{value}""";
-        }
-        if (valueType?.ToString() == "bool" && value is bool booleanValue)
-        {
-            return booleanValue ? "true" : "false";
-        }
-        if (value is int int32Value)
-        {
             return int32Value.ToString(CultureInfo.InvariantCulture);
         }
         else

--- a/src/dotnetCampus.Ipc.Analyzers/CodeAnalysis/Models/IpcShapeAttributeNamedValues.cs
+++ b/src/dotnetCampus.Ipc.Analyzers/CodeAnalysis/Models/IpcShapeAttributeNamedValues.cs
@@ -23,7 +23,7 @@ internal class IpcShapeAttributeNamedValues : IpcPublicAttributeNamedValues
     {
         return $@"new()
 {{
-    {Format(nameof(DefaultReturn), DefaultReturn, x => Format(x, MemberReturnType))}
+    {Format(nameof(DefaultReturn), DefaultReturn, x => x ?? "null")}
     {Format(nameof(Timeout), Timeout)}
     {Format(nameof(IgnoresIpcException), IgnoresIpcException)}
     {Format(nameof(IsReadonly), IsReadonly)}

--- a/src/dotnetCampus.Ipc.Analyzers/CodeAnalysis/Utils/IpcSemanticAttributeHelper.cs
+++ b/src/dotnetCampus.Ipc.Analyzers/CodeAnalysis/Utils/IpcSemanticAttributeHelper.cs
@@ -64,7 +64,7 @@ internal static class IpcSemanticAttributeHelper
         var waitsVoid = method.GetAttributeValue<IpcMethodAttribute, bool>(nameof(IpcMethodAttribute.WaitsVoid));
         var ignoresIpcException = method.GetAttributeValue<IpcMethodAttribute, bool>(nameof(IpcMethodAttribute.IgnoresIpcException))
             ?? type.GetAttributeValue<IpcPublicAttribute, bool>(nameof(IpcPublicAttribute.IgnoresIpcException));
-        var defaultReturn = method.GetAttributeValue<IpcMethodAttribute, object?>(nameof(IpcMethodAttribute.DefaultReturn));
+        var defaultReturn = method.GetAttributeValue<IpcMethodAttribute, string?>(nameof(IpcMethodAttribute.DefaultReturn));
         var timeout = method.GetAttributeValue<IpcMethodAttribute, int>(nameof(IpcMethodAttribute.Timeout))
             ?? type.GetAttributeValue<IpcPublicAttribute, int>(nameof(IpcPublicAttribute.Timeout));
         return new IpcPublicAttributeNamedValues(type, method, returnTypeSymbol)
@@ -88,7 +88,7 @@ internal static class IpcSemanticAttributeHelper
         var isReadonly = property.GetAttributeValue<IpcPropertyAttribute, bool>(nameof(IpcPropertyAttribute.IsReadonly));
         var ignoresIpcException = property.GetAttributeValue<IpcPropertyAttribute, bool>(nameof(IpcPropertyAttribute.IgnoresIpcException))
             ?? type.GetAttributeValue<IpcPublicAttribute, bool>(nameof(IpcPublicAttribute.IgnoresIpcException));
-        var defaultReturn = property.GetAttributeValue<IpcPropertyAttribute, object?>(nameof(IpcPropertyAttribute.DefaultReturn));
+        var defaultReturn = property.GetAttributeValue<IpcPropertyAttribute, string?>(nameof(IpcPropertyAttribute.DefaultReturn));
         var timeout = property.GetAttributeValue<IpcPropertyAttribute, int>(nameof(IpcPropertyAttribute.Timeout))
             ?? type.GetAttributeValue<IpcPublicAttribute, int>(nameof(IpcPublicAttribute.Timeout));
         return new IpcPublicAttributeNamedValues(type, property, property.Type)

--- a/src/dotnetCampus.Ipc.Analyzers/CodeAnalysis/Utils/SemanticAttributeHelper.cs
+++ b/src/dotnetCampus.Ipc.Analyzers/CodeAnalysis/Utils/SemanticAttributeHelper.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics;
-
-namespace dotnetCampus.Ipc.CodeAnalysis.Utils;
+﻿namespace dotnetCampus.Ipc.CodeAnalysis.Utils;
 
 /// <summary>
 /// 包含语义分析的辅助扩展方法。
@@ -15,10 +13,9 @@ internal static class SemanticAttributeHelper
     /// <param name="symbol">要查找特性的语义符号。</param>
     /// <param name="namedArgumentName">参数名称。</param>
     /// <returns>参数的值。</returns>
-    [return: MaybeNull]
     public static Assignable<T>? GetAttributeValue<TAttribute, T>(this ISymbol symbol, string namedArgumentName)
     {
-        var assignable = GetAttributeValue(symbol, typeof(TAttribute).FullName, namedArgumentName);
+        var assignable = GetAttributeValue(symbol, typeof(TAttribute).FullName!, namedArgumentName);
 
         // 未赋值。
         if (assignable is null)
@@ -28,6 +25,10 @@ internal static class SemanticAttributeHelper
 
         // 引用类型已赋值。
         if (typeof(T) == typeof(object))
+        {
+            return new((T?) assignable.Value);
+        }
+        else if (typeof(T) == typeof(string))
         {
             return new((T?) assignable.Value);
         }
@@ -64,7 +65,7 @@ internal static class SemanticAttributeHelper
         return symbol.GetAttributes().FirstOrDefault(x => string.Equals(
             x.AttributeClass?.ToString(),
             typeof(TAttribute).FullName,
-            StringComparison.Ordinal)) is { } ipcMethodAttribute;
+            StringComparison.Ordinal)) is not null;
     }
 
     /// <summary>

--- a/src/dotnetCampus.Ipc.Analyzers/Generators/IpcPublicGenerator.cs
+++ b/src/dotnetCampus.Ipc.Analyzers/Generators/IpcPublicGenerator.cs
@@ -45,57 +45,25 @@ public class IpcPublicGenerator : IIncrementalGenerator
 
     private void Execute(SourceProductionContext context, IpcPublicCompilation ipcPublicCompilation)
     {
-        try
-        {
-            var ipcType = ipcPublicCompilation.IpcType;
-            var proxySource = GenerateProxySource(ipcPublicCompilation);
-            var jointSource = GenerateJointSource(ipcPublicCompilation);
-            context.AddSource($"{ipcType.Name}.proxy.cs", SourceText.From(proxySource, Encoding.UTF8));
-            context.AddSource($"{ipcType.Name}.joint.cs", SourceText.From(jointSource, Encoding.UTF8));
-        }
-        catch (DiagnosticException ex)
-        {
-            ReportDiagnosticsThatHaveNotBeenReported(context, ex);
-        }
-        catch (Exception ex)
-        {
-            context.ReportDiagnostic(Diagnostic.Create(IPC000_UnknownError, null, ex));
-        }
+        var ipcType = ipcPublicCompilation.IpcType;
+        var proxySource = GenerateProxySource(ipcPublicCompilation);
+        var jointSource = GenerateJointSource(ipcPublicCompilation);
+        context.AddSource($"{ipcType.Name}.proxy.cs", SourceText.From(proxySource, Encoding.UTF8));
+        context.AddSource($"{ipcType.Name}.joint.cs", SourceText.From(jointSource, Encoding.UTF8));
     }
 
     private void Execute(SourceProductionContext context, IpcShapeCompilation ipcShapeCompilation)
     {
-        try
-        {
-            var contractType = ipcShapeCompilation.ContractType;
-            var ipcType = ipcShapeCompilation.IpcType;
-            var proxySource = GenerateProxySource(ipcShapeCompilation);
-            context.AddSource($"{contractType.Name}.{ipcType.Name}.shape.cs", SourceText.From(proxySource, Encoding.UTF8));
-        }
-        catch (DiagnosticException ex)
-        {
-            ReportDiagnosticsThatHaveNotBeenReported(context, ex);
-        }
-        catch (Exception ex)
-        {
-            context.ReportDiagnostic(Diagnostic.Create(IPC000_UnknownError, null, ex));
-        }
+        var contractType = ipcShapeCompilation.ContractType;
+        var ipcType = ipcShapeCompilation.IpcType;
+        var proxySource = GenerateProxySource(ipcShapeCompilation);
+        context.AddSource($"{contractType.Name}.{ipcType.Name}.shape.cs", SourceText.From(proxySource, Encoding.UTF8));
     }
 
-    private void Execute(SourceProductionContext context, (ImmutableArray<IpcPublicCompilation> IpcPublics, ImmutableArray<IpcShapeCompilation> IpcShapes) compilations)
+    private void Execute(SourceProductionContext context,
+        (ImmutableArray<IpcPublicCompilation> IpcPublics, ImmutableArray<IpcShapeCompilation> IpcShapes) compilations)
     {
-        try
-        {
-            var moduleInitializerSource = GenerateModuleInitializerSource(compilations.IpcPublics, compilations.IpcShapes);
-            context.AddSource("_ModuleInitializer.cs", SourceText.From(moduleInitializerSource, Encoding.UTF8));
-        }
-        catch (DiagnosticException ex)
-        {
-            ReportDiagnosticsThatHaveNotBeenReported(context, ex);
-        }
-        catch (Exception ex)
-        {
-            context.ReportDiagnostic(Diagnostic.Create(IPC000_UnknownError, null, ex));
-        }
+        var moduleInitializerSource = GenerateModuleInitializerSource(compilations.IpcPublics, compilations.IpcShapes);
+        context.AddSource("_ModuleInitializer.cs", SourceText.From(moduleInitializerSource, Encoding.UTF8));
     }
 }

--- a/src/dotnetCampus.Ipc/CompilerServices/Attributes/IpcMethodAttribute.cs
+++ b/src/dotnetCampus.Ipc/CompilerServices/Attributes/IpcMethodAttribute.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 
 namespace dotnetCampus.Ipc.CompilerServices.Attributes;
 
@@ -23,19 +24,29 @@ class IpcMethodAttribute : IpcMemberAttribute
     /// 在指定了 <see cref="IpcMemberAttribute.IgnoresIpcException"/> 或者 <see cref="IpcMemberAttribute.Timeout"/> 的情况下，如果真的发生了 IPC 连接异常或超时，则会使用此默认值。
     /// <list type="number">
     /// <item>不指定此值时，会使用属性或返回值类型的默认值（即 default）。</item>
-    /// <item>如果此值可使用编译时常量来表示，则直接写在这里即可。</item>
-    /// <item>如果此值无法写成编译时常量，请使用字符串形式编写（例如 "IntPtr.Zero" ，含英文引号），编译后会自动将其转为真实代码。</item>
+    /// <item>请使用字符串形式编写值（例如 "IntPtr.Zero" ，含英文引号），编译后会自动将其转为真实代码。</item>
     /// <item>
-    /// 接上条，如果你确实是一个 object 返回值但默认值是一个字符串，请写成以下两种中的一种：
-    /// <list type="bullet">
-    /// <item>@"""字符串值"""（含“@”及所有的英文引号）</item>
-    /// <item>"\"字符串值\""（含所有的英文引号及斜杠）</item>
-    /// </list>
+    /// 接上条，以下写法会在编译时转成对应的语句：
+    /// <code>
+    /// | 写法（含引号）   | 转成的语句       |
+    /// |------------------|------------------|
+    /// | null             | null             |
+    /// | "null"           | null             |
+    /// | default          | default          |
+    /// | "default"        | default          |
+    /// | "\"text\""       | "text"           |
+    /// | @"""text"""      | "text"           |
+    /// | "new Foo(2)"     | new Foo(2)       |
+    /// | "SomeEnum.Value" | SomeEnum.Value   |
+    /// </code>
     /// </item>
     /// </list>
     /// </summary>
     [DefaultValue(null)]
-    public object? DefaultReturn { get; set; }
+#if NET8_0_OR_GREATER
+    [StringSyntax("csharp")]
+#endif
+    public string? DefaultReturn { get; set; }
 
     /// <summary>
     /// 如果一个方法返回值是 void，那么此属性决定代理调用此方法时是否需要等待对方执行完成。

--- a/src/dotnetCampus.Ipc/CompilerServices/Attributes/IpcPropertyAttribute.cs
+++ b/src/dotnetCampus.Ipc/CompilerServices/Attributes/IpcPropertyAttribute.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 
 namespace dotnetCampus.Ipc.CompilerServices.Attributes;
 
@@ -23,19 +24,29 @@ sealed class IpcPropertyAttribute : IpcMemberAttribute
     /// 在指定了 <see cref="IpcMemberAttribute.IgnoresIpcException"/> 或者 <see cref="IpcMemberAttribute.Timeout"/> 的情况下，如果真的发生了 IPC 连接异常或超时，则会使用此默认值。
     /// <list type="number">
     /// <item>不指定此值时，会使用属性或返回值类型的默认值（即 default）。</item>
-    /// <item>如果此值可使用编译时常量来表示，则直接写在这里即可。</item>
-    /// <item>如果此值无法写成编译时常量，请使用字符串形式编写（例如 "IntPtr.Zero" ，含英文引号），编译后会自动将其转为真实代码。</item>
+    /// <item>请使用字符串形式编写值（例如 "IntPtr.Zero" ，含英文引号），编译后会自动将其转为真实代码。</item>
     /// <item>
-    /// 接上条，如果你确实是一个 object 返回值但默认值是一个字符串，请写成以下两种中的一种：
-    /// <list type="bullet">
-    /// <item>@"""字符串值"""（含“@”及所有的英文引号）</item>
-    /// <item>"\"字符串值\""（含所有的英文引号及斜杠）</item>
-    /// </list>
+    /// 接上条，以下写法会在编译时转成对应的语句：
+    /// <code>
+    /// | 写法（含引号）   | 转成的语句       |
+    /// |------------------|------------------|
+    /// | null             | null             |
+    /// | "null"           | null             |
+    /// | default          | default          |
+    /// | "default"        | default          |
+    /// | "\"text\""       | "text"           |
+    /// | @"""text"""      | "text"           |
+    /// | "new Foo(2)"     | new Foo(2)       |
+    /// | "SomeEnum.Value" | SomeEnum.Value   |
+    /// </code>
     /// </item>
     /// </list>
     /// </summary>
     [DefaultValue(null)]
-    public object? DefaultReturn { get; set; }
+#if NET8_0_OR_GREATER
+    [StringSyntax("csharp")]
+#endif
+    public string? DefaultReturn { get; set; }
 
     /// <summary>
     /// 标记一个属性是对于 IPC 代理访问来说是只读的。

--- a/tests/dotnetCampus.Ipc.Tests/CompilerServices/Fake/IFakeIpcObject.cs
+++ b/tests/dotnetCampus.Ipc.Tests/CompilerServices/Fake/IFakeIpcObject.cs
@@ -50,23 +50,23 @@ namespace dotnetCampus.Ipc.Tests.CompilerServices
         Task<FakeIpcObjectSubModelA?> MethodThatHasAsyncNullableComplexReturn();
 #nullable restore
 
-        [IpcMethod(DefaultReturn = "default1", IgnoresIpcException = true, Timeout = 100)]
+        [IpcMethod(DefaultReturn = "\"default1\"", IgnoresIpcException = true, Timeout = 100)]
         Task<string> MethodThatHasDefaultReturn();
 
         [IpcMethod(DefaultReturn = "default", IgnoresIpcException = true, Timeout = 100)]
         Task<object> MethodThatHasObjectWithObjectDefaultReturn();
 
-        [IpcMethod(DefaultReturn = @"""default1""", IgnoresIpcException = true, Timeout = 100)]
+        [IpcMethod(DefaultReturn = "\"default1\"", IgnoresIpcException = true, Timeout = 100)]
         Task<object> MethodThatHasObjectWithStringDefaultReturn();
 
         // 请不要将这里的 String 改为 string，这是为了测试代码生成器能否处理类型而非关键字。
-        [IpcMethod(DefaultReturn = "default1", IgnoresIpcException = true, Timeout = 100)]
+        [IpcMethod(DefaultReturn = "\"default1\"", IgnoresIpcException = true, Timeout = 100)]
         Task<String> MethodThatHasStringDefaultReturn();
 
         [IpcMethod(DefaultReturn = "new System.IntPtr(1)", IgnoresIpcException = true, Timeout = 100)]
         Task<IntPtr> MethodThatHasCustomDefaultReturn();
 
-        [IpcMethod(DefaultReturn = "default1")]
+        [IpcMethod(DefaultReturn = "\"default1\"")]
         Task<string> MethodThatCannotBeCompiled_MustSetOtherAttributes();
 
         Task<List<string>> MethodWithListParametersAndListReturn(List<string> a, List<string> b);


### PR DESCRIPTION
虽然让源生成器生成符合预期的代码更难一些，要多层引号，但不会再有歧义了，字符串里的东西一定是代码而不可能既可能是代码又可能是字符串