### PR TITLE
无论是主动连接还是被动连接进来，都有事件触发

### DIFF
--- a/src/dotnetCampus.Ipc/Internals/PeerManager.cs
+++ b/src/dotnetCampus.Ipc/Internals/PeerManager.cs
@@ -8,7 +8,10 @@ using dotnetCampus.Ipc.Pipes;
 
 namespace dotnetCampus.Ipc.Internals
 {
-    internal interface IPeerManager
+    /// <summary>
+    /// 管理所有连接方
+    /// </summary>
+    public interface IPeerManager
     {
         /// <summary>
         /// 和 <see cref="IpcProvider"/> 不同的是，无论是主动连接还是被动连过来的，都会触发此事件
@@ -16,15 +19,15 @@ namespace dotnetCampus.Ipc.Internals
         event EventHandler<PeerConnectedArgs>? PeerConnected;
 
         /// <summary>
-        /// 当前连接的数量。此属性仅有记日志的作用。由于 IPC 将会不断多进程连接和断开，所以这个数量是不断变化的。可能获取的一刻，实际情况就和此不相同
+        /// 当前连接的数量。无论是主动连接的还是被连接的对方都会记录在此。此属性仅有记日志的作用。由于 IPC 将会不断多进程连接和断开，所以这个数量是不断变化的。可能获取的一刻，实际情况就和此不相同
         /// </summary>
         int CurrentConnectedPeerProxyCount { get; }
 
         /// <summary>
-        /// 获取当前连接到的 <see cref="PeerProxy"/> 列表。仅表示获取时的状态，由于 IPC 将会不断多进程连接和断开，所以这个列表是不断变化的。可能获取的一刻，实际情况就和此不相同
+        /// 获取当前连接到的 <see cref="PeerProxy"/> 列表。无论是主动连接的还是被连接的对方都会记录在此。仅表示获取时的状态，由于 IPC 将会不断多进程连接和断开，所以这个列表是不断变化的。可能获取的一刻，实际情况就和此不相同
         /// </summary>
         /// <returns></returns>
-        IReadOnlyList <PeerProxy> GetCurrentConnectedPeerProxyList();
+        IReadOnlyList<PeerProxy> GetCurrentConnectedPeerProxyList();
     }
 
     class PeerManager : IPeerManager, IDisposable

--- a/src/dotnetCampus.Ipc/Internals/PeerManager.cs
+++ b/src/dotnetCampus.Ipc/Internals/PeerManager.cs
@@ -8,7 +8,26 @@ using dotnetCampus.Ipc.Pipes;
 
 namespace dotnetCampus.Ipc.Internals
 {
-    class PeerManager : IDisposable
+    internal interface IPeerManager
+    {
+        /// <summary>
+        /// 和 <see cref="IpcProvider"/> 不同的是，无论是主动连接还是被动连过来的，都会触发此事件
+        /// </summary>
+        event EventHandler<PeerConnectedArgs>? PeerConnected;
+
+        /// <summary>
+        /// 当前连接的数量。此属性仅有记日志的作用。由于 IPC 将会不断多进程连接和断开，所以这个数量是不断变化的。可能获取的一刻，实际情况就和此不相同
+        /// </summary>
+        int CurrentConnectedPeerProxyCount { get; }
+
+        /// <summary>
+        /// 获取当前连接到的 <see cref="PeerProxy"/> 列表。仅表示获取时的状态，由于 IPC 将会不断多进程连接和断开，所以这个列表是不断变化的。可能获取的一刻，实际情况就和此不相同
+        /// </summary>
+        /// <returns></returns>
+        IReadOnlyList <PeerProxy> GetCurrentConnectedPeerProxyList();
+    }
+
+    class PeerManager : IPeerManager, IDisposable
     {
         public PeerManager(IpcProvider ipcProvider)
         {
@@ -19,12 +38,12 @@ namespace dotnetCampus.Ipc.Internals
         {
             peerProxy.PeerConnectionBroken += PeerProxy_PeerConnectionBroken;
             OnAdd(peerProxy);
-            return ConnectedServerManagerDictionary.TryAdd(peerProxy.PeerName, peerProxy);
+            return ConnectedPeerProxyDictionary.TryAdd(peerProxy.PeerName, peerProxy);
         }
 
         public bool TryGetValue(string key, [NotNullWhen(true)] out PeerProxy? peer)
         {
-            return ConnectedServerManagerDictionary.TryGetValue(key, out peer);
+            return ConnectedPeerProxyDictionary.TryGetValue(key, out peer);
         }
 
         /// <summary>
@@ -38,7 +57,7 @@ namespace dotnetCampus.Ipc.Internals
                 throw new ArgumentException($"Must remove the Broken peer. PeerName={peerProxy.PeerName}");
             }
 
-            ConnectedServerManagerDictionary.TryRemove(peerProxy.PeerName, out var value);
+            ConnectedPeerProxyDictionary.TryRemove(peerProxy.PeerName, out var value);
 
             if (ReferenceEquals(peerProxy, value) || value is null)
             {
@@ -55,7 +74,7 @@ namespace dotnetCampus.Ipc.Internals
                         $"Peer 断开之后，从已有列表删除时发现列表里面记录的 Peer 和当前的不是相同的一个。仅调试下抛出。PeerName={peerProxy.PeerName}");
                 }
 
-                ConnectedServerManagerDictionary.TryAdd(value.PeerName, value);
+                ConnectedPeerProxyDictionary.TryAdd(value.PeerName, value);
             }
         }
 
@@ -70,7 +89,7 @@ namespace dotnetCampus.Ipc.Internals
 
             OnAdd(peerProxy);
             // 更新或注册，用于解决之前注册的实际上是断开的连接
-            ConnectedServerManagerDictionary.AddOrUpdate(peerProxy.PeerName, peerProxy, (s, proxy) => proxy);
+            ConnectedPeerProxyDictionary.AddOrUpdate(peerProxy.PeerName, peerProxy, (s, proxy) => proxy);
         }
 
         private void OnAdd(PeerProxy peerProxy)
@@ -82,6 +101,25 @@ namespace dotnetCampus.Ipc.Internals
                 peerProxy.PeerReConnector.ReconnectFail -= PeerReConnector_ReconnectFail;
                 peerProxy.PeerReConnector.ReconnectFail += PeerReConnector_ReconnectFail;
             }
+
+            if (!ConnectedPeerProxyDictionary.ContainsKey(peerProxy.PeerName))
+            {
+                // 没有从字典找到，证明是首次连接到的。或曾经断开过的，此后再连接的
+                PeerConnected?.Invoke(this, new PeerConnectedArgs(peerProxy));
+            }
+        }
+
+        /// <inheritdoc />
+        public event EventHandler<PeerConnectedArgs>? PeerConnected;
+
+        /// <inheritdoc />
+        public int CurrentConnectedPeerProxyCount => ConnectedPeerProxyDictionary.Count;
+
+        /// <inheritdoc />
+        public IReadOnlyList<PeerProxy> GetCurrentConnectedPeerProxyList()
+        {
+            // 这里是线程安全的，但只会返回当前的状态
+            return ConnectedPeerProxyDictionary.Values.ToList();
         }
 
         private void PeerReConnector_ReconnectFail(object? sender, ReconnectFailEventArgs e)
@@ -95,7 +133,7 @@ namespace dotnetCampus.Ipc.Internals
 
         public void Dispose()
         {
-            foreach (var pair in ConnectedServerManagerDictionary)
+            foreach (var pair in ConnectedPeerProxyDictionary)
             {
                 var peer = pair.Value;
                 // 为什么 PeerProxy 不加上 IDisposable 方法
@@ -104,7 +142,7 @@ namespace dotnetCampus.Ipc.Internals
             }
         }
 
-        private ConcurrentDictionary<string/*PeerName*/, PeerProxy> ConnectedServerManagerDictionary { get; } =
+        private ConcurrentDictionary<string/*PeerName*/, PeerProxy> ConnectedPeerProxyDictionary { get; } =
             new ConcurrentDictionary<string, PeerProxy>();
         private readonly IpcProvider _ipcProvider;
 

--- a/src/dotnetCampus.Ipc/Internals/PeerManager.cs
+++ b/src/dotnetCampus.Ipc/Internals/PeerManager.cs
@@ -19,12 +19,12 @@ namespace dotnetCampus.Ipc.Internals
         {
             peerProxy.PeerConnectionBroken += PeerProxy_PeerConnectionBroken;
             OnAdd(peerProxy);
-            return ConnectedServerManagerList.TryAdd(peerProxy.PeerName, peerProxy);
+            return ConnectedServerManagerDictionary.TryAdd(peerProxy.PeerName, peerProxy);
         }
 
         public bool TryGetValue(string key, [NotNullWhen(true)] out PeerProxy? peer)
         {
-            return ConnectedServerManagerList.TryGetValue(key, out peer);
+            return ConnectedServerManagerDictionary.TryGetValue(key, out peer);
         }
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace dotnetCampus.Ipc.Internals
                 throw new ArgumentException($"Must remove the Broken peer. PeerName={peerProxy.PeerName}");
             }
 
-            ConnectedServerManagerList.TryRemove(peerProxy.PeerName, out var value);
+            ConnectedServerManagerDictionary.TryRemove(peerProxy.PeerName, out var value);
 
             if (ReferenceEquals(peerProxy, value) || value is null)
             {
@@ -55,7 +55,7 @@ namespace dotnetCampus.Ipc.Internals
                         $"Peer 断开之后，从已有列表删除时发现列表里面记录的 Peer 和当前的不是相同的一个。仅调试下抛出。PeerName={peerProxy.PeerName}");
                 }
 
-                ConnectedServerManagerList.TryAdd(value.PeerName, value);
+                ConnectedServerManagerDictionary.TryAdd(value.PeerName, value);
             }
         }
 
@@ -70,7 +70,7 @@ namespace dotnetCampus.Ipc.Internals
 
             OnAdd(peerProxy);
             // 更新或注册，用于解决之前注册的实际上是断开的连接
-            ConnectedServerManagerList.AddOrUpdate(peerProxy.PeerName, peerProxy, (s, proxy) => proxy);
+            ConnectedServerManagerDictionary.AddOrUpdate(peerProxy.PeerName, peerProxy, (s, proxy) => proxy);
         }
 
         private void OnAdd(PeerProxy peerProxy)
@@ -95,7 +95,7 @@ namespace dotnetCampus.Ipc.Internals
 
         public void Dispose()
         {
-            foreach (var pair in ConnectedServerManagerList)
+            foreach (var pair in ConnectedServerManagerDictionary)
             {
                 var peer = pair.Value;
                 // 为什么 PeerProxy 不加上 IDisposable 方法
@@ -104,7 +104,7 @@ namespace dotnetCampus.Ipc.Internals
             }
         }
 
-        private ConcurrentDictionary<string, PeerProxy> ConnectedServerManagerList { get; } =
+        private ConcurrentDictionary<string/*PeerName*/, PeerProxy> ConnectedServerManagerDictionary { get; } =
             new ConcurrentDictionary<string, PeerProxy>();
         private readonly IpcProvider _ipcProvider;
 

--- a/src/dotnetCampus.Ipc/Pipes/IpcProvider.cs
+++ b/src/dotnetCampus.Ipc/Pipes/IpcProvider.cs
@@ -40,13 +40,13 @@ namespace dotnetCampus.Ipc.Pipes
             IpcContext.IpcConfiguration.AddFrameworkRequestHandler(IpcContext.GeneratedProxyJointIpcContext.RequestHandler);
             IpcContext.Logger.Trace($"[IpcProvider] 本地服务名 {pipeName}");
 
-            _peerManager = new PeerManager(this);
+            PeerManagerInternal = new PeerManager(this);
         }
 
         /// <inheritdoc />
         public IpcContext IpcContext { get; }
 
-        private readonly PeerManager _peerManager;
+        private PeerManager PeerManagerInternal { get; }
 
         /// <summary>
         /// 是否启动了
@@ -109,7 +109,7 @@ namespace dotnetCampus.Ipc.Pipes
                 IpcContext.Logger.Debug($"[OnPeerConnected]IpcProvider.OnPeerConnected PeerName={e.PeerName};CurrentName={IpcContext.PipeName}");
 
                 // 也许是对方反过来连接
-                if (_peerManager.TryGetValue(e.PeerName, out var peerProxy))
+                if (PeerManagerInternal.TryGetValue(e.PeerName, out var peerProxy))
                 {
                     IpcContext.Logger.Debug($"[OnPeerConnected]PeerManager.TryGetValue Success. PeerName={e.PeerName};CurrentName={IpcContext.PipeName}");
 
@@ -117,7 +117,7 @@ namespace dotnetCampus.Ipc.Pipes
                     if (peerProxy.IsBroken && !IpcContext.IpcConfiguration.AutoReconnectPeers)
                     {
                         // 理论上不会进入这个分支，因为如果 IsBroken 将会自动去清理，除非刚好一个断开，然后立刻连接
-                        _peerManager.RemovePeerProxy(peerProxy);
+                        PeerManagerInternal.RemovePeerProxy(peerProxy);
                         await ConnectBackToPeer(e);
                     }
                     else
@@ -211,7 +211,7 @@ namespace dotnetCampus.Ipc.Pipes
             var peerName = e.PeerName;
             //var receivedAck = e.Ack;
 
-            if (_peerManager.TryGetValue(peerName, out _))
+            if (PeerManagerInternal.TryGetValue(peerName, out _))
             {
                 // 预期不会进入此分支，也就是之前没有连接过才对
                 Debug.Assert(false, "对方连接之前没有记录对方");
@@ -269,7 +269,7 @@ namespace dotnetCampus.Ipc.Pipes
             {
                 var peerProxy = new PeerProxy(e.PeerName, ipcClientService, e, IpcContext);
 
-                if (_peerManager.TryAdd(peerProxy))
+                if (PeerManagerInternal.TryAdd(peerProxy))
                 {
                     // 理论上会进入此分支，除非是此时收到了多次的发送
                 }
@@ -319,7 +319,7 @@ namespace dotnetCampus.Ipc.Pipes
         {
             var peerProxy = await GetOrCreatePeerProxyAsync(peerName);
 
-            await _peerManager.WaitForPeerConnectFinishedAsync(peerProxy);
+            await PeerManagerInternal.WaitForPeerConnectFinishedAsync(peerProxy);
 
             return peerProxy;
         }
@@ -333,7 +333,7 @@ namespace dotnetCampus.Ipc.Pipes
         /// 为什么会存在 <paramref name="shouldWaitPeerConnectFinished"/> 参数，这是为了解决极端情况下，刚好本进程能连接到对方，连接完成瞬间，对方挂了，无法反向连接回来的情况。正常不需要设置此参数
         public async Task<ConnectToExistingPeerResult> TryConnectToExistingPeerAsync(string peerName, bool shouldWaitPeerConnectFinished = true)
         {
-            if (_peerManager.TryGetValue(peerName, out var peerProxy))
+            if (PeerManagerInternal.TryGetValue(peerName, out var peerProxy))
             {
 
             }
@@ -358,14 +358,14 @@ namespace dotnetCampus.Ipc.Pipes
 
                 // 需要确定能连接上对方了，才能加入到 PeerManager 里面。确保不会在下次进来的时候，拿到了一个无法建立连接的 Peer 对象。这里的添加顺序是先确保连接再添加，这就意味着在并行的时候，可能会多次尝试连接。这是符合预期的，本身连接也没有多少损耗，最多只会多创建一个管道而已
                 peerProxy = new PeerProxy(peerName, ipcClientService, IpcContext);
-                _peerManager.TryAdd(peerProxy);
+                PeerManagerInternal.TryAdd(peerProxy);
 
                 // 在 PeerProxy 加入到管理之后，才能向对方注册自己，确保对方收到注册之后，反过来向自己注册时，可以从管理里面拿到注册的对方信息，从而让 PeerManager.WaitForPeerConnectFinishedAsync 能够完成
                 await ipcClientService.RegisterToPeerAsync();
             }
 
             // 等待对方回连，建立双向连接
-            Task peerConnectFinishedTask = _peerManager.WaitForPeerConnectFinishedAsync(peerProxy);
+            Task peerConnectFinishedTask = PeerManagerInternal.WaitForPeerConnectFinishedAsync(peerProxy);
             if (shouldWaitPeerConnectFinished)
             {
                 try
@@ -394,7 +394,7 @@ namespace dotnetCampus.Ipc.Pipes
         /// <returns></returns>
         internal async Task<PeerProxy> GetOrCreatePeerProxyAsync(string peerName)
         {
-            if (_peerManager.TryGetValue(peerName, out var peerProxy))
+            if (PeerManagerInternal.TryGetValue(peerName, out var peerProxy))
             {
             }
             else
@@ -413,7 +413,7 @@ namespace dotnetCampus.Ipc.Pipes
             var ipcClientService = CreateIpcClientService(peerName);
 
             var peerProxy = new PeerProxy(peerName, ipcClientService, IpcContext);
-            _peerManager.TryAdd(peerProxy);
+            PeerManagerInternal.TryAdd(peerProxy);
 
             await ipcClientService.Start().ConfigureAwait(false);
 
@@ -429,7 +429,7 @@ namespace dotnetCampus.Ipc.Pipes
             IpcContext.IsDisposing = true;
             IpcContext.Logger.Trace($"[IpcProvider][Dispose] {IpcContext.PipeName}");
             IpcServerService.Dispose();
-            _peerManager.Dispose();
+            PeerManagerInternal.Dispose();
             IpcContext.IsDisposed = true;
         }
 

--- a/src/dotnetCampus.Ipc/Pipes/IpcProvider.cs
+++ b/src/dotnetCampus.Ipc/Pipes/IpcProvider.cs
@@ -40,13 +40,13 @@ namespace dotnetCampus.Ipc.Pipes
             IpcContext.IpcConfiguration.AddFrameworkRequestHandler(IpcContext.GeneratedProxyJointIpcContext.RequestHandler);
             IpcContext.Logger.Trace($"[IpcProvider] 本地服务名 {pipeName}");
 
-            PeerManager = new PeerManager(this);
+            _peerManager = new PeerManager(this);
         }
 
         /// <inheritdoc />
         public IpcContext IpcContext { get; }
 
-        private PeerManager PeerManager { get; }
+        private readonly PeerManager _peerManager;
 
         /// <summary>
         /// 是否启动了
@@ -109,7 +109,7 @@ namespace dotnetCampus.Ipc.Pipes
                 IpcContext.Logger.Debug($"[OnPeerConnected]IpcProvider.OnPeerConnected PeerName={e.PeerName};CurrentName={IpcContext.PipeName}");
 
                 // 也许是对方反过来连接
-                if (PeerManager.TryGetValue(e.PeerName, out var peerProxy))
+                if (_peerManager.TryGetValue(e.PeerName, out var peerProxy))
                 {
                     IpcContext.Logger.Debug($"[OnPeerConnected]PeerManager.TryGetValue Success. PeerName={e.PeerName};CurrentName={IpcContext.PipeName}");
 
@@ -117,7 +117,7 @@ namespace dotnetCampus.Ipc.Pipes
                     if (peerProxy.IsBroken && !IpcContext.IpcConfiguration.AutoReconnectPeers)
                     {
                         // 理论上不会进入这个分支，因为如果 IsBroken 将会自动去清理，除非刚好一个断开，然后立刻连接
-                        PeerManager.RemovePeerProxy(peerProxy);
+                        _peerManager.RemovePeerProxy(peerProxy);
                         await ConnectBackToPeer(e);
                     }
                     else
@@ -211,7 +211,7 @@ namespace dotnetCampus.Ipc.Pipes
             var peerName = e.PeerName;
             //var receivedAck = e.Ack;
 
-            if (PeerManager.TryGetValue(peerName, out _))
+            if (_peerManager.TryGetValue(peerName, out _))
             {
                 // 预期不会进入此分支，也就是之前没有连接过才对
                 Debug.Assert(false, "对方连接之前没有记录对方");
@@ -269,7 +269,7 @@ namespace dotnetCampus.Ipc.Pipes
             {
                 var peerProxy = new PeerProxy(e.PeerName, ipcClientService, e, IpcContext);
 
-                if (PeerManager.TryAdd(peerProxy))
+                if (_peerManager.TryAdd(peerProxy))
                 {
                     // 理论上会进入此分支，除非是此时收到了多次的发送
                 }
@@ -319,7 +319,7 @@ namespace dotnetCampus.Ipc.Pipes
         {
             var peerProxy = await GetOrCreatePeerProxyAsync(peerName);
 
-            await PeerManager.WaitForPeerConnectFinishedAsync(peerProxy);
+            await _peerManager.WaitForPeerConnectFinishedAsync(peerProxy);
 
             return peerProxy;
         }
@@ -333,7 +333,7 @@ namespace dotnetCampus.Ipc.Pipes
         /// 为什么会存在 <paramref name="shouldWaitPeerConnectFinished"/> 参数，这是为了解决极端情况下，刚好本进程能连接到对方，连接完成瞬间，对方挂了，无法反向连接回来的情况。正常不需要设置此参数
         public async Task<ConnectToExistingPeerResult> TryConnectToExistingPeerAsync(string peerName, bool shouldWaitPeerConnectFinished = true)
         {
-            if (PeerManager.TryGetValue(peerName, out var peerProxy))
+            if (_peerManager.TryGetValue(peerName, out var peerProxy))
             {
 
             }
@@ -358,14 +358,14 @@ namespace dotnetCampus.Ipc.Pipes
 
                 // 需要确定能连接上对方了，才能加入到 PeerManager 里面。确保不会在下次进来的时候，拿到了一个无法建立连接的 Peer 对象。这里的添加顺序是先确保连接再添加，这就意味着在并行的时候，可能会多次尝试连接。这是符合预期的，本身连接也没有多少损耗，最多只会多创建一个管道而已
                 peerProxy = new PeerProxy(peerName, ipcClientService, IpcContext);
-                PeerManager.TryAdd(peerProxy);
+                _peerManager.TryAdd(peerProxy);
 
                 // 在 PeerProxy 加入到管理之后，才能向对方注册自己，确保对方收到注册之后，反过来向自己注册时，可以从管理里面拿到注册的对方信息，从而让 PeerManager.WaitForPeerConnectFinishedAsync 能够完成
                 await ipcClientService.RegisterToPeerAsync();
             }
 
             // 等待对方回连，建立双向连接
-            Task peerConnectFinishedTask = PeerManager.WaitForPeerConnectFinishedAsync(peerProxy);
+            Task peerConnectFinishedTask = _peerManager.WaitForPeerConnectFinishedAsync(peerProxy);
             if (shouldWaitPeerConnectFinished)
             {
                 try
@@ -394,7 +394,7 @@ namespace dotnetCampus.Ipc.Pipes
         /// <returns></returns>
         internal async Task<PeerProxy> GetOrCreatePeerProxyAsync(string peerName)
         {
-            if (PeerManager.TryGetValue(peerName, out var peerProxy))
+            if (_peerManager.TryGetValue(peerName, out var peerProxy))
             {
             }
             else
@@ -413,7 +413,7 @@ namespace dotnetCampus.Ipc.Pipes
             var ipcClientService = CreateIpcClientService(peerName);
 
             var peerProxy = new PeerProxy(peerName, ipcClientService, IpcContext);
-            PeerManager.TryAdd(peerProxy);
+            _peerManager.TryAdd(peerProxy);
 
             await ipcClientService.Start().ConfigureAwait(false);
 
@@ -429,7 +429,7 @@ namespace dotnetCampus.Ipc.Pipes
             IpcContext.IsDisposing = true;
             IpcContext.Logger.Trace($"[IpcProvider][Dispose] {IpcContext.PipeName}");
             IpcServerService.Dispose();
-            PeerManager.Dispose();
+            _peerManager.Dispose();
             IpcContext.IsDisposed = true;
         }
 

--- a/src/dotnetCampus.Ipc/Pipes/IpcProvider.cs
+++ b/src/dotnetCampus.Ipc/Pipes/IpcProvider.cs
@@ -301,6 +301,9 @@ namespace dotnetCampus.Ipc.Pipes
         /// <summary>
         /// 本机作为服务端，有对方连接过来时触发
         /// </summary>
+        /// <remarks>
+        /// 仅被动连接（被对方连接过来）时触发。主动去连接对方时，不会触发此事件。如需要获取无论是主动还是被动连接过来的事件，请使用 <see cref="IPeerManager.PeerConnected"/> 事件
+        /// </remarks>
         public event EventHandler<PeerConnectedArgs>? PeerConnected;
 
         /// <summary>

--- a/src/dotnetCampus.Ipc/Pipes/IpcProvider.cs
+++ b/src/dotnetCampus.Ipc/Pipes/IpcProvider.cs
@@ -46,6 +46,11 @@ namespace dotnetCampus.Ipc.Pipes
         /// <inheritdoc />
         public IpcContext IpcContext { get; }
 
+        /// <summary>
+        /// 管理所有连接方
+        /// </summary>
+        public IPeerManager PeerManager => PeerManagerInternal;
+
         private PeerManager PeerManagerInternal { get; }
 
         /// <summary>

--- a/src/dotnetCampus.Ipc/Pipes/IpcServerService.cs
+++ b/src/dotnetCampus.Ipc/Pipes/IpcServerService.cs
@@ -85,7 +85,7 @@ namespace dotnetCampus.Ipc.Pipes
         }
 
         /// <summary>
-        /// 当收到消息时触发
+        /// 当收到消息时触发。无论是哪个 Peer 收到消息，都会引发此事件
         /// </summary>
         public event EventHandler<PeerMessageArgs>? MessageReceived;
 
@@ -94,6 +94,11 @@ namespace dotnetCampus.Ipc.Pipes
         /// </summary>
         internal event EventHandler<IpcInternalPeerConnectedArgs>? PeerConnected;
 
+        /// <summary>
+        /// 当接收到消息时触发。无论是哪个 Peer 收到消息，都会引发此事件
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
         internal void OnMessageReceived(object? sender, PeerStreamMessageArgs e)
         {
             string? debugMessageBody = null;

--- a/src/dotnetCampus.Ipc/Pipes/IpcServerService.cs
+++ b/src/dotnetCampus.Ipc/Pipes/IpcServerService.cs
@@ -50,7 +50,7 @@ namespace dotnetCampus.Ipc.Pipes
         /// 启动服务
         /// </summary>
         /// <returns></returns>
-        public async Task Start()
+        internal async Task Start()
         {
             while (!_isDisposed)
             {

--- a/tests/dotnetCampus.Ipc.Tests/PeerManagerTest.cs
+++ b/tests/dotnetCampus.Ipc.Tests/PeerManagerTest.cs
@@ -1,0 +1,293 @@
+﻿using dotnetCampus.Ipc.Pipes;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace dotnetCampus.Ipc.Tests;
+
+[TestClass]
+public class PeerManagerTest
+{
+    [TestMethod("无论是主动连接还是被动连接，都能触发 PeerManager.PeerConnected 事件")]
+    public async Task TestPeerManager1()
+    {
+        var nameA = "PeerManagerTest_1";
+        var nameB = "PeerManagerTest_2";
+
+        var a = new IpcProvider(nameA);
+        var b = new IpcProvider(nameB);
+
+        var aPeerManagerConnectedCount = 0;
+        var bPeerManagerConnectedCount = 0;
+
+        a.PeerManager.PeerConnected += (sender, args) =>
+        {
+            aPeerManagerConnectedCount++;
+        };
+
+        b.PeerManager.PeerConnected += (sender, args) =>
+        {
+            bPeerManagerConnectedCount++;
+        };
+
+        var aIpcProviderConnectedCount = 0;
+        var bIpcProviderConnectedCount = 0;
+
+        a.PeerConnected += (sender, args) =>
+        {
+            aIpcProviderConnectedCount++;
+        };
+        var bConnectedTaskCompletionSource = new TaskCompletionSource();
+        b.PeerConnected += (sender, args) =>
+        {
+            bIpcProviderConnectedCount++;
+            bConnectedTaskCompletionSource.SetResult();
+        };
+
+        a.StartServer();
+
+        Task<PeerProxy> connectTask = a.GetAndConnectToPeerAsync(nameB);
+
+        Assert.IsFalse(connectTask.IsCompleted, "由于此时 B 服务还没启动，必定现在还没连接完成");
+        // 这里有一个小争议点，那就是事件名为 PeerConnected 但实际上可能没有完全完成连接的建立
+        Assert.AreEqual(1, aPeerManagerConnectedCount, "已经主动在 a 发起连接，此时有一个记录");
+        Assert.AreEqual(0, bPeerManagerConnectedCount, "还没有完成建立连接，必定现在是 0 的值");
+
+        Assert.AreEqual(0, aIpcProviderConnectedCount, "还没有完成建立连接，必定现在是 0 的值");
+        Assert.AreEqual(0, bIpcProviderConnectedCount, "还没有完成建立连接，必定现在是 0 的值");
+
+        // 开启 B 服务了，预期现在能够完成连接
+        b.StartServer();
+
+        // 等待连接
+        await connectTask;
+
+        // 由于 b 是在另一个线程\进程跑的，不是在当前单元测试所在的线程跑的。需要等待一下，避免多线程执行顺序，导致单元测试概率不通过
+        await Task.WhenAny(bConnectedTaskCompletionSource.Task, Task.Delay(TimeSpan.FromSeconds(3)));
+
+        // 连接完成之后，预期现在无论是 a 还是 b 的 PeerManager 都有一次连接触发。但 IpcProvider 的 PeerConnected 只有 b 被动连接的一次触发
+        Assert.AreEqual(1, aPeerManagerConnectedCount, "连接完成之后，无论主动连接，都能让 PeerManager.PeerConnected 事件触发");
+        Assert.AreEqual(1, bPeerManagerConnectedCount, "连接完成之后，无论主动连接，都能让 PeerManager.PeerConnected 事件触发");
+
+        Assert.AreEqual(0, aIpcProviderConnectedCount, "连接完成之后，只有被动连接才能让 IpcProvider.PeerConnected 事件触发。由于是 a 主动连接 b 的，因此 a 的 IpcProvider.PeerConnected 事件没有触发");
+        Assert.AreEqual(1, bIpcProviderConnectedCount, "连接完成之后，只有被动连接才能让 IpcProvider.PeerConnected 事件触发。由于是 a 主动连接 b 的，因此 b 的 IpcProvider.PeerConnected 事件触发");
+
+        // 当前连接只有一项
+        Assert.AreEqual(1, a.PeerManager.CurrentConnectedPeerProxyCount);
+        Assert.AreEqual(1, b.PeerManager.CurrentConnectedPeerProxyCount);
+
+        Assert.AreEqual(1, a.PeerManager.GetCurrentConnectedPeerProxyList().Count);
+        Assert.AreEqual(1, b.PeerManager.GetCurrentConnectedPeerProxyList().Count);
+
+        // 现在 a 所连接的就是 b 的
+        Assert.AreEqual(nameB, a.PeerManager.GetCurrentConnectedPeerProxyList()[0].PeerName);
+        // 现在 b 所连接的就是 a 的
+        Assert.AreEqual(nameA, b.PeerManager.GetCurrentConnectedPeerProxyList()[0].PeerName);
+    }
+
+    [TestMethod("a 主动连接 b 和 c，测试三端的 PeerManager.PeerConnected 事件和连接数量")]
+    public async Task TestPeerManager2()
+    {
+        var nameA = "PeerManagerTest2_A";
+        var nameB = "PeerManagerTest2_B";
+        var nameC = "PeerManagerTest2_C";
+
+        var a = new IpcProvider(nameA);
+        var b = new IpcProvider(nameB);
+        var c = new IpcProvider(nameC);
+
+        var aPeerManagerConnectedCount = 0;
+        var bPeerManagerConnectedCount = 0;
+        var cPeerManagerConnectedCount = 0;
+
+        a.PeerManager.PeerConnected += (sender, args) =>
+        {
+            aPeerManagerConnectedCount++;
+        };
+
+        b.PeerManager.PeerConnected += (sender, args) =>
+        {
+            bPeerManagerConnectedCount++;
+        };
+
+        c.PeerManager.PeerConnected += (sender, args) =>
+        {
+            cPeerManagerConnectedCount++;
+        };
+
+        var aIpcProviderConnectedCount = 0;
+        var bIpcProviderConnectedCount = 0;
+        var cIpcProviderConnectedCount = 0;
+
+        a.PeerConnected += (sender, args) =>
+        {
+            aIpcProviderConnectedCount++;
+        };
+
+        var bConnectedTaskCompletionSource = new TaskCompletionSource();
+        b.PeerConnected += (sender, args) =>
+        {
+            bIpcProviderConnectedCount++;
+            bConnectedTaskCompletionSource.SetResult();
+        };
+
+        var cConnectedTaskCompletionSource = new TaskCompletionSource();
+        c.PeerConnected += (sender, args) =>
+        {
+            cIpcProviderConnectedCount++;
+            cConnectedTaskCompletionSource.SetResult();
+        };
+
+        a.StartServer();
+
+        Task<PeerProxy> connectToBTask = a.GetAndConnectToPeerAsync(nameB);
+        Task<PeerProxy> connectToCTask = a.GetAndConnectToPeerAsync(nameC);
+
+        Assert.IsFalse(connectToBTask.IsCompleted, "由于此时 B 服务还没启动，必定现在还没连接完成");
+        Assert.IsFalse(connectToCTask.IsCompleted, "由于此时 C 服务还没启动，必定现在还没连接完成");
+        // 这里有一个小争议点，那就是事件名为 PeerConnected 但实际上可能没有完全完成连接的建立
+        Assert.AreEqual(2, aPeerManagerConnectedCount, "a 主动发起连接 b 和 c，此时已有两个记录");
+        Assert.AreEqual(0, bPeerManagerConnectedCount, "还没有完成建立连接，必定现在是 0 的值");
+        Assert.AreEqual(0, cPeerManagerConnectedCount, "还没有完成建立连接，必定现在是 0 的值");
+
+        Assert.AreEqual(0, aIpcProviderConnectedCount, "还没有完成建立连接，必定现在是 0 的值");
+        Assert.AreEqual(0, bIpcProviderConnectedCount, "还没有完成建立连接，必定现在是 0 的值");
+        Assert.AreEqual(0, cIpcProviderConnectedCount, "还没有完成建立连接，必定现在是 0 的值");
+
+        // 开启 B 和 C 服务了，预期现在能够完成连接
+        b.StartServer();
+        c.StartServer();
+
+        // 等待连接
+        await Task.WhenAll(connectToBTask, connectToCTask);
+
+        // 由于 b 和 c 是在另一个线程跑的，需要等待一下，避免多线程执行顺序，导致单元测试概率不通过
+        await Task.WhenAny(
+            Task.WhenAll(bConnectedTaskCompletionSource.Task, cConnectedTaskCompletionSource.Task),
+            Task.Delay(TimeSpan.FromSeconds(3)));
+
+        Assert.AreEqual(2, aPeerManagerConnectedCount, "连接完成之后，a 主动连接 b 和 c，PeerManager.PeerConnected 触发两次");
+        Assert.AreEqual(1, bPeerManagerConnectedCount, "连接完成之后，b 被 a 连接，PeerManager.PeerConnected 触发一次");
+        Assert.AreEqual(1, cPeerManagerConnectedCount, "连接完成之后，c 被 a 连接，PeerManager.PeerConnected 触发一次");
+
+        Assert.AreEqual(0, aIpcProviderConnectedCount, "a 是主动连接方，IpcProvider.PeerConnected 事件不触发");
+        Assert.AreEqual(1, bIpcProviderConnectedCount, "b 是被动连接方，IpcProvider.PeerConnected 事件触发一次");
+        Assert.AreEqual(1, cIpcProviderConnectedCount, "c 是被动连接方，IpcProvider.PeerConnected 事件触发一次");
+
+        Assert.AreEqual(2, a.PeerManager.CurrentConnectedPeerProxyCount);
+        Assert.AreEqual(1, b.PeerManager.CurrentConnectedPeerProxyCount);
+        Assert.AreEqual(1, c.PeerManager.CurrentConnectedPeerProxyCount);
+
+        Assert.AreEqual(2, a.PeerManager.GetCurrentConnectedPeerProxyList().Count);
+        Assert.AreEqual(1, b.PeerManager.GetCurrentConnectedPeerProxyList().Count);
+        Assert.AreEqual(1, c.PeerManager.GetCurrentConnectedPeerProxyList().Count);
+
+        // a 连接了 b 和 c，顺序不保证，用名称集合验证
+        var aConnectedPeerNames = a.PeerManager.GetCurrentConnectedPeerProxyList().Select(p => p.PeerName).ToHashSet();
+        Assert.IsTrue(aConnectedPeerNames.Contains(nameB), "a 连接的列表中应包含 b");
+        Assert.IsTrue(aConnectedPeerNames.Contains(nameC), "a 连接的列表中应包含 c");
+
+        // b 和 c 各自只连了 a
+        Assert.AreEqual(nameA, b.PeerManager.GetCurrentConnectedPeerProxyList()[0].PeerName);
+        Assert.AreEqual(nameA, c.PeerManager.GetCurrentConnectedPeerProxyList()[0].PeerName);
+    }
+
+    [TestMethod("b 和 c 主动连接 a，测试三端的 PeerManager.PeerConnected 事件和连接数量")]
+    public async Task TestPeerManager3()
+    {
+        var nameA = "PeerManagerTest3_A";
+        var nameB = "PeerManagerTest3_B";
+        var nameC = "PeerManagerTest3_C";
+
+        var a = new IpcProvider(nameA);
+        var b = new IpcProvider(nameB);
+        var c = new IpcProvider(nameC);
+
+        var aPeerManagerConnectedCount = 0;
+        var bPeerManagerConnectedCount = 0;
+        var cPeerManagerConnectedCount = 0;
+
+        a.PeerManager.PeerConnected += (sender, args) =>
+        {
+            aPeerManagerConnectedCount++;
+        };
+
+        b.PeerManager.PeerConnected += (sender, args) =>
+        {
+            bPeerManagerConnectedCount++;
+        };
+
+        c.PeerManager.PeerConnected += (sender, args) =>
+        {
+            cPeerManagerConnectedCount++;
+        };
+
+        var aIpcProviderConnectedCount = 0;
+        var bIpcProviderConnectedCount = 0;
+        var cIpcProviderConnectedCount = 0;
+
+        var aAllConnectedTaskCompletionSource = new TaskCompletionSource();
+        a.PeerConnected += (sender, args) =>
+        {
+            aIpcProviderConnectedCount++;
+            if (aIpcProviderConnectedCount >= 2)
+            {
+                aAllConnectedTaskCompletionSource.TrySetResult();
+            }
+        };
+
+        b.PeerConnected += (sender, args) =>
+        {
+            bIpcProviderConnectedCount++;
+        };
+
+        c.PeerConnected += (sender, args) =>
+        {
+            cIpcProviderConnectedCount++;
+        };
+
+        a.StartServer();
+        b.StartServer();
+        c.StartServer();
+
+        Task<PeerProxy> bConnectToATask = b.GetAndConnectToPeerAsync(nameA);
+        Task<PeerProxy> cConnectToATask = c.GetAndConnectToPeerAsync(nameA);
+
+        // 这里有一个小争议点，那就是事件名为 PeerConnected 但实际上可能没有完全完成连接的建立
+        Assert.AreEqual(1, bPeerManagerConnectedCount, "b 主动发起连接 a，此时 b 有一个记录");
+        Assert.AreEqual(1, cPeerManagerConnectedCount, "c 主动发起连接 a，此时 c 有一个记录");
+
+        Assert.AreEqual(0, bIpcProviderConnectedCount, "b 是主动连接方，IpcProvider.PeerConnected 事件不触发");
+        Assert.AreEqual(0, cIpcProviderConnectedCount, "c 是主动连接方，IpcProvider.PeerConnected 事件不触发");
+
+        // 等待连接
+        await Task.WhenAll(bConnectToATask, cConnectToATask);
+
+        // 由于 a 是在另一个线程跑的，需要等待一下，避免多线程执行顺序，导致单元测试概率不通过
+        await Task.WhenAny(aAllConnectedTaskCompletionSource.Task, Task.Delay(TimeSpan.FromSeconds(3)));
+
+        Assert.AreEqual(2, aPeerManagerConnectedCount, "连接完成之后，a 被 b 和 c 连接，PeerManager.PeerConnected 触发两次");
+        Assert.AreEqual(1, bPeerManagerConnectedCount, "b 主动连接 a，PeerManager.PeerConnected 触发一次");
+        Assert.AreEqual(1, cPeerManagerConnectedCount, "c 主动连接 a，PeerManager.PeerConnected 触发一次");
+
+        Assert.AreEqual(2, aIpcProviderConnectedCount, "a 是被动连接方，IpcProvider.PeerConnected 事件触发两次");
+        Assert.AreEqual(0, bIpcProviderConnectedCount, "b 是主动连接方，IpcProvider.PeerConnected 事件不触发");
+        Assert.AreEqual(0, cIpcProviderConnectedCount, "c 是主动连接方，IpcProvider.PeerConnected 事件不触发");
+
+        Assert.AreEqual(2, a.PeerManager.CurrentConnectedPeerProxyCount);
+        Assert.AreEqual(1, b.PeerManager.CurrentConnectedPeerProxyCount);
+        Assert.AreEqual(1, c.PeerManager.CurrentConnectedPeerProxyCount);
+
+        Assert.AreEqual(2, a.PeerManager.GetCurrentConnectedPeerProxyList().Count);
+        Assert.AreEqual(1, b.PeerManager.GetCurrentConnectedPeerProxyList().Count);
+        Assert.AreEqual(1, c.PeerManager.GetCurrentConnectedPeerProxyList().Count);
+
+        // a 被 b 和 c 连接，顺序不保证，用名称集合验证
+        var aConnectedPeerNames = a.PeerManager.GetCurrentConnectedPeerProxyList().Select(p => p.PeerName).ToHashSet();
+        Assert.IsTrue(aConnectedPeerNames.Contains(nameB), "a 连接的列表中应包含 b");
+        Assert.IsTrue(aConnectedPeerNames.Contains(nameC), "a 连接的列表中应包含 c");
+
+        // b 和 c 各自只连了 a
+        Assert.AreEqual(nameA, b.PeerManager.GetCurrentConnectedPeerProxyList()[0].PeerName);
+        Assert.AreEqual(nameA, c.PeerManager.GetCurrentConnectedPeerProxyList()[0].PeerName);
+    }
+}


### PR DESCRIPTION
需求：

- 可以在框架层面做统一处理，有很多应用情况都是 P2P 的方式。可能是主动连但也可能是被动连接过来的。期望有一个事件可以做统一的处理
- 有日志或调试需求，了解当前有多少连接数，需要获取 CurrentConnectedPeerProxyCount 数量

额外提供 GetCurrentConnectedPeerProxyList 方法，用于获取列表，虽然获取列表时候只能代表当前的状态，但对于一些记录日志或调试业务来说也足够了