### PR TITLE
让 IPC 支持到 .NET Core 3.1 版本的非管理员和管理员权限进程通讯

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,6 +25,7 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="System.Collections.Immutable" Version="9.0.10" />
     <PackageVersion Include="System.IO.Pipelines" Version="8.0.0" />
+    <PackageVersion Include="System.IO.Pipes.AccessControl" Version="5.0.0" />
     <PackageVersion Include="System.Text.Json" Version="8.0.6" />
     <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
     <PackageVersion Include="Walterlv.NullableAttributes.Source" Version="7.4.0" />

--- a/demo/dotnetCampus.Ipc.Demo/Program.cs
+++ b/demo/dotnetCampus.Ipc.Demo/Program.cs
@@ -13,55 +13,79 @@ namespace dotnetCampus.Ipc.Demo
 {
     internal class Program
     {
-        private static async Task Main(string[] args)
+        private static void Main(string[] args)
+        {
+            // 为了测试 NET 45 和 NET Core 3.1 版本，才这么写的
+            MainAsync(args).GetAwaiter().GetResult();
+        }
+
+        private static async Task MainAsync(string[] args)
         {
             var ipcProvider = new IpcProvider();
             ipcProvider.StartServer();
+
+            ipcProvider.PeerConnected += (sender, connectedArgs) =>
+            {
+                Console.WriteLine($"[{GetCurrentProcessId()}] 收到 {connectedArgs.Peer.PeerName} 的连接");
+
+                connectedArgs.Peer.MessageReceived += async (o, messageArgs) =>
+                {
+                    Console.WriteLine($"[{GetCurrentProcessId()}] 收到 {messageArgs.PeerName} 的消息：{GetMessageText(messageArgs.Message.Body)}");
+
+                    await Task.Delay(TimeSpan.FromSeconds(1));
+
+                    // 反向发送消息给对方
+                    Console.WriteLine($"[{GetCurrentProcessId()}] 向 {connectedArgs.Peer.PeerName} 回复消息");
+                    await connectedArgs.Peer.NotifyAsync(new IpcMessage("回复", Encoding.UTF8.GetBytes($"收到你的消息")));
+                    Console.WriteLine($"[{GetCurrentProcessId()}] 完成向 {connectedArgs.Peer.PeerName} 回复消息");
+                };
+            };
 
             if (args.Length == 0)
             {
                 var currentName = ipcProvider.IpcContext.PipeName;
                 // 将当前的进程的 Name 传递给另一个进程，用来达成通讯
-                var mainModuleFileName = Process.GetCurrentProcess().MainModule.FileName;
-                Console.WriteLine($"[{Environment.ProcessId}] 准备启动 {mainModuleFileName} 参数：{currentName}");
+                var currentProcess = Process.GetCurrentProcess();
+                var mainModule = currentProcess.MainModule;
+                if (mainModule == null)
+                {
+                    throw new InvalidOperationException("无法获取当前进程的主模块路径。");
+                }
+
+                var mainModuleFileName = mainModule.FileName;
+                Console.WriteLine($"[{GetCurrentProcessId()}] 准备启动 {mainModuleFileName} 参数：{currentName}");
+
                 Process.Start(mainModuleFileName, currentName);
             }
             else
             {
                 // 这是被启动的进程，主动连接发送消息
-                Console.WriteLine($"[{Environment.ProcessId}] 开始连接对方进程");
+                Console.WriteLine($"[{GetCurrentProcessId()}] 开始连接对方进程");
 
                 var peer = await ipcProvider.GetAndConnectToPeerAsync(args[0]);
                 peer.MessageReceived += (sender, messageArgs) =>
                 {
                     Console.WriteLine(
-                        $"[{Environment.ProcessId}] 收到 {peer.PeerName} 的回复消息：{Encoding.UTF8.GetString(messageArgs.Message.Body.AsSpan())}");
+                        $"[{GetCurrentProcessId()}] 收到 {peer.PeerName} 的回复消息：{GetMessageText(messageArgs.Message.Body)}");
                 };
                 await peer.NotifyAsync(new IpcMessage("Hello",
-                    Encoding.UTF8.GetBytes($"Hello,进程号是 {Environment.ProcessId} 发送过来消息")));
-                Console.WriteLine($"[{Environment.ProcessId}] 完成发送消息");
+                    Encoding.UTF8.GetBytes($"Hello,进程号是 {GetCurrentProcessId()} 发送过来消息")));
+                Console.WriteLine($"[{GetCurrentProcessId()}] 完成发送消息");
             }
 
-            ipcProvider.PeerConnected += (sender, connectedArgs) =>
-            {
-                Console.WriteLine($"[{Environment.ProcessId}] 收到 {connectedArgs.Peer.PeerName} 的连接");
-
-                connectedArgs.Peer.MessageReceived += async (o, messageArgs) =>
-                {
-                    Console.WriteLine($"[{Environment.ProcessId}] 收到 {messageArgs.PeerName} 的消息：{Encoding.UTF8.GetString(messageArgs.Message.Body.AsSpan())}");
-
-                    await Task.Delay(TimeSpan.FromSeconds(1));
-
-                    // 反向发送消息给对方
-                    Console.WriteLine($"[{Environment.ProcessId}] 向 {connectedArgs.Peer.PeerName} 回复消息");
-                    await connectedArgs.Peer.NotifyAsync(new IpcMessage("回复", Encoding.UTF8.GetBytes($"收到你的消息")));
-                    Console.WriteLine($"[{Environment.ProcessId}] 完成向 {connectedArgs.Peer.PeerName} 回复消息");
-                };
-            };
-
-            Console.WriteLine($"[{Environment.ProcessId}] 等待退出");
+            Console.WriteLine($"[{GetCurrentProcessId()}] 等待退出");
             Console.Read();
-            Console.WriteLine($"[{Environment.ProcessId}] 进程准备退出");
+            Console.WriteLine($"[{GetCurrentProcessId()}] 进程准备退出");
+        }
+
+        private static int GetCurrentProcessId()
+        {
+            return Process.GetCurrentProcess().Id;
+        }
+
+        private static string GetMessageText(IpcMessageBody body)
+        {
+            return Encoding.UTF8.GetString(body.Buffer, body.Start, body.Length);
         }
     }
 }

--- a/demo/dotnetCampus.Ipc.Demo/dotnetCampus.Ipc.Demo.csproj
+++ b/demo/dotnetCampus.Ipc.Demo/dotnetCampus.Ipc.Demo.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0;netcoreapp3.1;net45</TargetFrameworks>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
-    <PublishAot>true</PublishAot>
+    <PublishAot Condition="'$(TargetFramework)' == 'net9.0'">true</PublishAot>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dotnetCampus.Ipc/Internals/IpcPipeServerMessageProvider.cs
+++ b/src/dotnetCampus.Ipc/Internals/IpcPipeServerMessageProvider.cs
@@ -2,13 +2,17 @@
 using System.Diagnostics;
 using System.IO;
 using System.IO.Pipes;
+using System.Runtime.InteropServices;
 using System.Security.AccessControl;
+using System.Security.Permissions;
 using System.Security.Principal;
 using System.Threading.Tasks;
 
 using dotnetCampus.Ipc.Context;
 using dotnetCampus.Ipc.Pipes;
 using dotnetCampus.Ipc.Utils.Extensions;
+
+using Microsoft.Win32.SafeHandles;
 
 namespace dotnetCampus.Ipc.Internals
 {
@@ -79,7 +83,8 @@ namespace dotnetCampus.Ipc.Internals
             serverStreamMessageConverter.AckReceived += IpcContext.AckManager.OnAckReceived;
             serverStreamMessageConverter.PeerConnected += IpcServerService.OnPeerConnected;
             serverStreamMessageConverter.MessageReceived += IpcServerService.OnMessageReceived;
-            serverStreamMessageConverter.PeerConnectBroke += (sender, args) => PeerConnectBroke?.Invoke(sender, new IpcPipeServerMessageProviderPeerConnectionBrokenArgs(this, args));
+            serverStreamMessageConverter.PeerConnectBroke += (sender, args) =>
+                PeerConnectBroke?.Invoke(sender, new IpcPipeServerMessageProviderPeerConnectionBrokenArgs(this, args));
 
             serverStreamMessageConverter.Run();
         }
@@ -93,8 +98,8 @@ namespace dotnetCampus.Ipc.Internals
         {
             NamedPipeServerStream namedPipeServerStream;
 
-#if NET6_0_OR_GREATER
-            if (System.OperatingSystem.IsWindows())
+#if NETCOREAPP
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 // 用来在 Windows 下，混用管理员权限和非管理员权限的管道
                 SecurityIdentifier securityIdentifier = new SecurityIdentifier(
@@ -105,6 +110,7 @@ namespace dotnetCampus.Ipc.Internals
                     PipeAccessRights.ReadWrite | PipeAccessRights.CreateNewInstance,
                     AccessControlType.Allow));
 
+#if NET6_0_OR_GREATER
                 // 这个 NamedPipeServerStreamAcl 是在 .NET 5 引入的
                 namedPipeServerStream = NamedPipeServerStreamAcl.Create
                 (
@@ -120,11 +126,34 @@ namespace dotnetCampus.Ipc.Internals
                     inBufferSize: 0, // If it is 0, the buffer size is allocated as needed.
                     outBufferSize: 0, // If it is 0, the buffer size is allocated as needed.
                     pipeSecurity
-                //, HandleInheritability.None 默认值
-                //, PipeAccessRights.ReadWrite 默认值
+                    //, HandleInheritability.None 默认值
+                    //, PipeAccessRights.ReadWrite 默认值
                 );
+#else
+                // ===== 仅 .NET Core 3.1 使用：通过 P/Invoke 创建带 PipeSecurity 的命名管道 =====
+                // .NET Core 3.1 上 NamedPipeServerStream 既不接受 PipeSecurity，
+                // 也没有 NamedPipeServerStreamAcl（该 API 仅 .NET 5+ 才在 System.IO.Pipes.AccessControl 中提供）；
+                // 而 System.IO.Pipes.AccessControl 包虽然能装上并暴露 PipesAclExtensions.SetAccessControl，
+                // 但 .NET Core 3.1 上 NamedPipeServerStream 创建出的句柄不带 WRITE_DAC 权限，
+                // 事后再 SetAccessControl 会在 SetSecurityInfo 处抛 UnauthorizedAccessException。
+                // 因此通过 P/Invoke 调用 CreateNamedPipe，在创建时直接传入安全描述符。
+                namedPipeServerStream = CreateNamedPipeServerStreamWithSecurity(PipeName,
+                    // 本框架使用两个半工做双向通讯，因此这里只是接收，不做发送
+                    PipeDirection.In,
+                    // 旧框架采用默认为 260 个实例链接，这里减少 10 个，没有具体的理由，待测试
+                    250,
+                    // 默认都采用 byte 方式
+
+                    PipeTransmissionMode.Byte,
+                    // 采用异步的方式。如果没有设置，默认是同步方式，即使有 Async 的方法，底层也是走同步
+                    PipeOptions.Asynchronous,
+                   inBufferSize: 0, // If it is 0, the buffer size is allocated as needed.
+                    outBufferSize: 0, // If it is 0, the buffer size is allocated as needed.
+                    pipeSecurity);
+#endif
                 return namedPipeServerStream;
             }
+
 #elif NETFRAMEWORK
             // .Net Framework 就不再判断 Windows 了
             SecurityIdentifier securityIdentifier = new SecurityIdentifier(
@@ -154,17 +183,17 @@ namespace dotnetCampus.Ipc.Internals
 #endif
             // 如果非 Windows 平台，或者非 .NET 6 / .Net Framework 应用，那就不加上权限
             namedPipeServerStream = new NamedPipeServerStream
-            (
-                PipeName,
-                // 本框架使用两个半工做双向通讯，因此这里只是接收，不做发送
-                PipeDirection.In,
-                // 旧框架采用默认为 260 个实例链接，这里减少 10 个，没有具体的理由，待测试
-                250,
-                // 默认都采用 byte 方式
-                PipeTransmissionMode.Byte,
-                // 采用异步的方式。如果没有设置，默认是同步方式，即使有 Async 的方法，底层也是走同步
-                PipeOptions.Asynchronous
-            );
+        (
+            PipeName,
+            // 本框架使用两个半工做双向通讯，因此这里只是接收，不做发送
+            PipeDirection.In,
+            // 旧框架采用默认为 260 个实例链接，这里减少 10 个，没有具体的理由，待测试
+            250,
+            // 默认都采用 byte 方式
+            PipeTransmissionMode.Byte,
+            // 采用异步的方式。如果没有设置，默认是同步方式，即使有 Async 的方法，底层也是走同步
+            PipeOptions.Asynchronous
+        );
 
             return namedPipeServerStream;
         }
@@ -205,5 +234,99 @@ namespace dotnetCampus.Ipc.Internals
                 ServerStreamMessageReader.Dispose();
             }
         }
+
+#if NETCOREAPP && !NET5_0_OR_GREATER
+        // ===== 仅 .NET Core 3.1 使用：通过 P/Invoke 创建带 PipeSecurity 的命名管道 =====
+        private const uint PIPE_ACCESS_DUPLEX = 0x00000003;
+        private const uint PIPE_ACCESS_INBOUND = 0x00000001;
+        private const uint PIPE_ACCESS_OUTBOUND = 0x00000002;
+        private const uint FILE_FLAG_OVERLAPPED = 0x40000000;
+        private const uint FILE_FLAG_WRITE_THROUGH = 0x80000000;
+        private const uint PIPE_TYPE_BYTE = 0x00000000;
+        private const uint PIPE_TYPE_MESSAGE = 0x00000004;
+
+        [StructLayout(LayoutKind.Sequential)]
+        struct SECURITY_ATTRIBUTES
+        {
+            public int nLength;
+            public IntPtr lpSecurityDescriptor;
+            public int bInheritHandle;
+        }
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode, EntryPoint = "CreateNamedPipeW")]
+        private static extern SafePipeHandle CreateNamedPipe(
+            string lpName,
+            uint dwOpenMode,
+            uint dwPipeMode,
+            uint nMaxInstances,
+            uint nOutBufferSize,
+            uint nInBufferSize,
+            uint nDefaultTimeOut,
+            ref SECURITY_ATTRIBUTES lpSecurityAttributes);
+
+        /// <summary>
+        /// 通过 Win32 CreateNamedPipe 创建带访问控制的命名管道，并包装为 <see cref="NamedPipeServerStream"/>。
+        /// 这是 .NET Core 3.1 上唯一能在创建时附带 <see cref="PipeSecurity"/> 的方式。
+        /// </summary>
+        private static NamedPipeServerStream CreateNamedPipeServerStreamWithSecurity(
+            string pipeName, PipeDirection direction, int maxInstances,
+            PipeTransmissionMode transmissionMode, PipeOptions options,
+            int inBufferSize, int outBufferSize, PipeSecurity pipeSecurity)
+        {
+            uint openMode;
+            switch (direction)
+            {
+                case PipeDirection.In: openMode = PIPE_ACCESS_INBOUND; break;
+                case PipeDirection.Out: openMode = PIPE_ACCESS_OUTBOUND; break;
+                default: openMode = PIPE_ACCESS_DUPLEX; break;
+            }
+
+            if ((options & PipeOptions.Asynchronous) != 0) openMode |= FILE_FLAG_OVERLAPPED;
+            if ((options & PipeOptions.WriteThrough) != 0) openMode |= FILE_FLAG_WRITE_THROUGH;
+
+            uint pipeMode = transmissionMode == PipeTransmissionMode.Message
+                ? PIPE_TYPE_MESSAGE
+                : PIPE_TYPE_BYTE;
+
+            // 将托管 PipeSecurity 转为原生安全描述符
+            var sdBytes = pipeSecurity.GetSecurityDescriptorBinaryForm();
+            GCHandle pinned = GCHandle.Alloc(sdBytes, GCHandleType.Pinned);
+            try
+            {
+                var sa = new SECURITY_ATTRIBUTES
+                {
+                    nLength = Marshal.SizeOf(typeof(SECURITY_ATTRIBUTES)),
+                    lpSecurityDescriptor = pinned.AddrOfPinnedObject(),
+                    bInheritHandle = 0,
+                };
+
+                var fullName = @"\\.\pipe\" + pipeName;
+                var handle = CreateNamedPipe(fullName, openMode, pipeMode,
+                    (uint) maxInstances, (uint) outBufferSize, (uint) inBufferSize, 0, ref sa);
+
+                if (handle.IsInvalid)
+                {
+                    var error = Marshal.GetLastWin32Error();
+                    handle.Dispose();
+                    // 与原构造函数行为保持一致：管道已存在 / 被占用时抛 IOException，
+                    // 权限不足时抛 UnauthorizedAccessException，外层 catch 会处理。
+                    const int ERROR_ACCESS_DENIED = 5;
+                    if (error == ERROR_ACCESS_DENIED)
+                    {
+                        throw new UnauthorizedAccessException();
+                    }
+
+                    throw new IOException("CreateNamedPipe 失败，Win32 错误码：" + error);
+                }
+
+                var isAsync = (options & PipeOptions.Asynchronous) != 0;
+                return new NamedPipeServerStream(direction, isAsync, false, handle);
+            }
+            finally
+            {
+                pinned.Free();
+            }
+        }
+#endif
     }
 }

--- a/src/dotnetCampus.Ipc/dotnetCampus.Ipc.csproj
+++ b/src/dotnetCampus.Ipc/dotnetCampus.Ipc.csproj
@@ -68,6 +68,10 @@
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="System.IO.Pipes.AccessControl" />
+  </ItemGroup>
+
   <!-- 生成 NuGet 包。 -->
   <Target Name="_IncludeAllDependencies" BeforeTargets="_GetPackageFiles">
     <ItemGroup>


### PR DESCRIPTION
测试了 .NET Core 3.1 的管理员权限和非管理员权限的相互通讯

<img width="1172" height="928" alt="image" src="https://github.com/user-attachments/assets/b3752408-a6c2-461f-ab90-46971c2d21fb" />
